### PR TITLE
增加 xmake 构建支持

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 110
+AccessModifierOffset: -4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.vscode/
-bin/
 build/
-lib/
-.VSCodeCounter/
+.cache/
+.xmake/
+compile_commands.json

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"

--- a/bin/config/publish/test.publish.com.yaml
+++ b/bin/config/publish/test.publish.com.yaml
@@ -3,10 +3,10 @@ name: test.publish.com
 key_file: test.publish.com.key
 cert_file: test.publish.com.crt
 apps:
-  - name: app                   #接入点名称
+  - name: app #接入点名称
     record:
       enabled: false
-      types: 
+      types:
         - ts
         - flv
     # edge_push:
@@ -20,12 +20,10 @@ apps:
     #     params:
     #       time: get_time()
     #       sign: md5_upper(sys@test.publish.com/${domain}/${app}/${stream}/${params[time]})
-    # origin_pull:
-    #   protocol: rtmp
-    #   url: rtmp://test.publish.com:1936/${app}/${stream}?time=${params[time]}&sign=${params[sign]}
-    #   params:
-    #     time: get_time()
-    #     sign: md5_upper(sys@test.publish.com/${domain}/${app}/${stream}/${params[time]})
+    origin_pull:
+      enabled: true
+      protocol: http-flv
+      url: https://test.play.com:1443/${app}/${stream_name}.flv
     publish_auth_check: #限时鉴权sk(expiry_sk)
       enabled: false
       params:
@@ -41,7 +39,7 @@ apps:
         - "${url_params[token]} == ${params[Token]}"
         - "${url_params[e]} > ${params[time]}"
     # http_callbacks:             # 回调配置
-    #   on_publish: 
+    #   on_publish:
     #       - async: false
     #         url: http://mms.com:8082/api/on_publish?sign=${params[sign]}&expire=${params[time]}
     #         params:
@@ -61,34 +59,35 @@ apps:
     #             "create_at": "${params[t1]}"
     #             "expire_at": ${params[time]}
     #           }
-    hls:                        # 切片配置
-      ts_min_seg_dur: 2000      # 2000ms，默认2000ms，单位ms
-      ts_max_seg_dur: 6000      # 6000ms就必须切片，默认6000ms，单位ms
-      ts_max_bytes: 2m          # 最大2m，默认2M，单位支持k/m
-      min_ts_count_for_m3u8: 3  #3个就可以输出m3u8，默认3
-    bridge:                     #转协议配置
-      no_players_timeout_ms: 10s  #多少时间无人播放，转协议结束
+    hls: # 切片配置
+      ts_min_seg_dur: 2000 # 2000ms，默认2000ms，单位ms
+      ts_max_seg_dur: 6000 # 6000ms就必须切片，默认6000ms，单位ms
+      ts_max_bytes: 2m # 最大2m，默认2M，单位支持k/m
+      min_ts_count_for_m3u8: 3 #3个就可以输出m3u8，默认3
+    bridge: #转协议配置
+      no_players_timeout_ms: 10s #多少时间无人播放，转协议结束
       rtmp:
-        to_flv: on              #使能rtmp转flv
-        to_hls: on              #使能rtmp转hls
-        to_rtsp: on             #使能rtmp转rtsp
-        to_webrtc: on           #使能rtmp转webrtc
+        to_flv: on #使能rtmp转flv
+        to_hls: on #使能rtmp转hls
+        to_rtsp: on #使能rtmp转rtsp
+        to_webrtc: on #使能rtmp转webrtc
       flv:
-        to_rtmp: on             #使能flv转rtmp
-        to_hls: on              #使能flv转hls
-        to_rtsp: on             #使能flv转rtsp
-        to_webrtc: on           #使能flv转webrtc
+        to_rtmp: on #使能flv转rtmp
+        to_hls: on #使能flv转hls
+        to_rtsp: on #使能flv转rtsp
+        to_webrtc: on #使能flv转webrtc
       rtsp:
-        to_rtmp: on             #使能rtsp转rtmp
-        to_flv: on              #使能rtsp转flv
-        to_hls: on              #使能rtsp转hls
-        to_webrtc: on           #使能rtsp转webrtc
+        to_rtmp: on #使能rtsp转rtmp
+        to_flv: on #使能rtsp转flv
+        to_hls: on #使能rtsp转hls
+        to_webrtc: on #使能rtsp转webrtc
       webrtc:
-        to_rtmp: on             #使能webrtc转rtmp
-        to_flv: on              #使能webrtc转flv
-        to_hls: on              #使能webrtc转hls
-        to_rtsp: on             #使能webrtc转rtsp
-    
+        to_rtmp: on #使能webrtc转rtmp
+        to_flv: on #使能webrtc转flv
+        to_hls: on #使能webrtc转hls
+        to_rtsp: on #使能webrtc转rtsp
+
+
     # origin_pull:
     #   protocol: rtmp
     #   url: rtmp://test.publish.com:1936/{app}/{stream}?time={params[time]}&sign={params[sign]}
@@ -118,4 +117,3 @@ apps:
     #   checks:
     #     - {url_params[token]} == params[Token]}
     #     - <({url_params[e]},params[time])
-    

--- a/libs/base/network/tcp_socket.cpp
+++ b/libs/base/network/tcp_socket.cpp
@@ -1,83 +1,80 @@
+#include "tcp_socket.hpp"
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/experimental/awaitable_operators.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/write.hpp>
 #include <iostream>
 #include <span>
 #include <variant>
-#include <boost/asio/experimental/awaitable_operators.hpp>
-#include <boost/asio/redirect_error.hpp>
-#include <boost/asio/write.hpp>
-#include <boost/asio/read.hpp>
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
 
 #include "base/utils/utils.h"
-#include "tcp_socket.hpp"
 #include "spdlog/spdlog.h"
 
 using namespace boost::asio::experimental::awaitable_operators;
 namespace mms {
-TcpSocket::TcpSocket(SocketInterfaceHandler *handler, boost::asio::ip::tcp::socket sock, ThreadWorker *worker) : 
-                                                        SocketInterface(handler),
-                                                        worker_(worker), 
-                                                        socket_(std::move(sock)), 
-                                                        connect_timeout_timer_(worker->get_io_context()),
-                                                        recv_timeout_timer_(worker->get_io_context()), 
-                                                        send_timeout_timer_(worker->get_io_context()),
-                                                        active_timeout_timer_(worker->get_io_context())
-{
-}
+TcpSocket::TcpSocket(SocketInterfaceHandler *handler, boost::asio::ip::tcp::socket sock, ThreadWorker *worker)
+    : SocketInterface(handler),
+      worker_(worker),
+      socket_(std::move(sock)),
+      connect_timeout_timer_(worker->get_io_context()),
+      recv_timeout_timer_(worker->get_io_context()),
+      send_timeout_timer_(worker->get_io_context()),
+      active_timeout_timer_(worker->get_io_context()) {}
 
-TcpSocket::TcpSocket(SocketInterfaceHandler *handler, ThreadWorker *worker):
-                                                        SocketInterface(handler), 
-                                                        worker_(worker), 
-                                                        socket_(worker->get_io_context()), 
-                                                        connect_timeout_timer_(worker->get_io_context()),
-                                                        recv_timeout_timer_(worker->get_io_context()), 
-                                                        send_timeout_timer_(worker->get_io_context()),
-                                                        active_timeout_timer_(worker->get_io_context())  
-{
-}
+TcpSocket::TcpSocket(SocketInterfaceHandler *handler, ThreadWorker *worker)
+    : SocketInterface(handler),
+      worker_(worker),
+      socket_(worker->get_io_context()),
+      connect_timeout_timer_(worker->get_io_context()),
+      recv_timeout_timer_(worker->get_io_context()),
+      send_timeout_timer_(worker->get_io_context()),
+      active_timeout_timer_(worker->get_io_context()) {}
 
-void TcpSocket::set_socket_inactive_timeout_ms(uint32_t ms) {
-    socket_inactive_timeout_ms_ = ms;
-}
+void TcpSocket::set_socket_inactive_timeout_ms(uint32_t ms) { socket_inactive_timeout_ms_ = ms; }
 
-TcpSocket::~TcpSocket() {
-    spdlog::debug("destroy TcpSocket");
-}
+TcpSocket::~TcpSocket() { spdlog::debug("destroy TcpSocket"); }
 
 void TcpSocket::open() {
     auto self(shared_from_this());
     if (handler_) {
         handler_->on_socket_open(self);
     }
-    
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        active_time_ = Utils::get_current_ms();
-        while (1) {
-            active_timeout_timer_.expires_from_now(std::chrono::milliseconds(socket_inactive_timeout_ms_));
-            boost::system::error_code ec;
-            co_await active_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
-            }
 
-            auto now = Utils::get_current_ms();
-            if (now - active_time_ >= socket_inactive_timeout_ms_) {
-                spdlog::debug("tcp socket[{}] active timeout", id_);
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            active_time_ = Utils::get_current_ms();
+            while (1) {
+                active_timeout_timer_.expires_after(std::chrono::milliseconds(socket_inactive_timeout_ms_));
+                boost::system::error_code ec;
+                co_await active_timeout_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
+                }
+
+                auto now = Utils::get_current_ms();
+                if (now - active_time_ >= socket_inactive_timeout_ms_) {
+                    spdlog::debug("tcp socket[{}] active timeout", id_);
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            close();
+        });
 }
 
 void TcpSocket::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
         return;
     }
-    
+
     active_timeout_timer_.cancel();
     if (handler_) {
         handler_->on_socket_close(shared_from_this());
@@ -85,20 +82,21 @@ void TcpSocket::close() {
     socket_.close();
 }
 
-boost::asio::awaitable<bool> TcpSocket::connect(const std::string & ip, uint16_t port, int32_t timeout_ms) {
-    boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address::from_string(ip), port);
+boost::asio::awaitable<bool> TcpSocket::connect(const std::string &ip, uint16_t port, int32_t timeout_ms) {
+    boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::make_address(ip), port);
     boost::system::error_code ec;
     if (timeout_ms > 0) {
-        active_timeout_timer_.expires_from_now(std::chrono::milliseconds(timeout_ms));
-        auto results = co_await(socket_.async_connect(endpoint, boost::asio::redirect_error(boost::asio::use_awaitable, ec)) ||
-                                connect_timeout_timer_.async_wait(boost::asio::use_awaitable));
-        if (results.index() == 1) {//超时
+        active_timeout_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
+        auto results = co_await (
+            socket_.async_connect(endpoint, boost::asio::redirect_error(boost::asio::use_awaitable, ec)) ||
+            connect_timeout_timer_.async_wait(boost::asio::use_awaitable));
+        if (results.index() == 1) {  // 超时
             co_return false;
         }
     } else {
         co_await socket_.async_connect(endpoint, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     }
-    
+
     if (ec) {
         co_return false;
     }
@@ -110,21 +108,20 @@ boost::asio::awaitable<bool> TcpSocket::connect(const std::string & ip, uint16_t
 boost::asio::awaitable<bool> TcpSocket::send(const uint8_t *data, size_t len, int32_t timeout_ms) {
     int32_t send_bytes = 0;
     if (timeout_ms > 0) {
-        send_timeout_timer_.expires_from_now(std::chrono::milliseconds(timeout_ms));
+        send_timeout_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
         std::variant<bool, std::monostate> results;
-        results = co_await(
-            [data, len, &send_bytes, this]()->boost::asio::awaitable<bool>{
-                boost::system::error_code ec;
-                send_bytes = co_await boost::asio::async_write(socket_, boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
-                    co_return false;
-                }
-                co_return true;
-            }() ||
-            send_timeout_timer_.async_wait(boost::asio::use_awaitable)
-        );
+        results = co_await ([data, len, &send_bytes, this]() -> boost::asio::awaitable<bool> {
+            boost::system::error_code ec;
+            send_bytes = co_await boost::asio::async_write(
+                socket_, boost::asio::buffer(data, len),
+                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return false;
+            }
+            co_return true;
+        }() || send_timeout_timer_.async_wait(boost::asio::use_awaitable));
 
-        if (results.index() == 1) {//超时
+        if (results.index() == 1) {  // 超时
             co_return false;
         }
 
@@ -133,50 +130,52 @@ boost::asio::awaitable<bool> TcpSocket::send(const uint8_t *data, size_t len, in
         }
     } else {
         boost::system::error_code ec;
-        send_bytes = co_await boost::asio::async_write(socket_, boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        send_bytes =
+            co_await boost::asio::async_write(socket_, boost::asio::buffer(data, len),
+                                              boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         if (ec) {
             co_return false;
         }
     }
-    
+
     out_bytes_ += send_bytes;
     active_time_ = Utils::get_current_ms();
     co_return true;
 }
 
-boost::asio::awaitable<bool> TcpSocket::send(std::vector<boost::asio::const_buffer> & bufs, int32_t timeout_ms) {
+boost::asio::awaitable<bool> TcpSocket::send(std::vector<boost::asio::const_buffer> &bufs,
+                                             int32_t timeout_ms) {
     int32_t send_bytes = 0;
     if (timeout_ms > 0) {
         send_timeout_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
         std::variant<bool, std::monostate> results;
-        results = co_await(
-            [&bufs, &send_bytes, this]()->boost::asio::awaitable<bool>{
-                boost::system::error_code ec;
-                std::span sbufs(bufs);
-                send_bytes = co_await boost::asio::async_write(socket_, bufs, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
-                    co_return false;
-                }
-                co_return true;
-            }() ||
-            send_timeout_timer_.async_wait(boost::asio::use_awaitable)
-        );
+        results = co_await ([&bufs, &send_bytes, this]() -> boost::asio::awaitable<bool> {
+            boost::system::error_code ec;
+            std::span sbufs(bufs);
+            send_bytes = co_await boost::asio::async_write(
+                socket_, bufs, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return false;
+            }
+            co_return true;
+        }() || send_timeout_timer_.async_wait(boost::asio::use_awaitable));
 
-        if (results.index() == 1) {//超时
+        if (results.index() == 1) {  // 超时
             co_return false;
         }
-        
-        if(!std::get<0>(results)) {
+
+        if (!std::get<0>(results)) {
             co_return false;
         }
     } else {
         boost::system::error_code ec;
-        send_bytes = co_await boost::asio::async_write(socket_, bufs, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        send_bytes = co_await boost::asio::async_write(
+            socket_, bufs, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         if (ec) {
             co_return false;
         }
     }
-    
+
     out_bytes_ += send_bytes;
     active_time_ = Utils::get_current_ms();
     co_return true;
@@ -184,35 +183,34 @@ boost::asio::awaitable<bool> TcpSocket::send(std::vector<boost::asio::const_buff
 
 boost::asio::awaitable<bool> TcpSocket::recv(uint8_t *data, size_t len, int32_t timeout_ms) {
     if (timeout_ms > 0) {
-        recv_timeout_timer_.expires_from_now(std::chrono::milliseconds(timeout_ms));
+        recv_timeout_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
         std::variant<bool, std::monostate> results;
-        results = co_await(
-            [data, len, this]()->boost::asio::awaitable<bool> {
-                boost::system::error_code ec;
-                co_await boost::asio::async_read(socket_, boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
-                    co_return false;
-                }
-                co_return true;
-            }() ||
-            recv_timeout_timer_.async_wait(boost::asio::use_awaitable)
-        );
+        results = co_await ([data, len, this]() -> boost::asio::awaitable<bool> {
+            boost::system::error_code ec;
+            co_await boost::asio::async_read(socket_, boost::asio::buffer(data, len),
+                                             boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return false;
+            }
+            co_return true;
+        }() || recv_timeout_timer_.async_wait(boost::asio::use_awaitable));
 
-        if (results.index() == 1) {//超时
-            co_return false;//考虑下返回码的问题,error应该需要包装下，但还得考虑性能
+        if (results.index() == 1) {  // 超时
+            co_return false;         // 考虑下返回码的问题,error应该需要包装下，但还得考虑性能
         }
-        
+
         if (!std::get<0>(results)) {
             co_return false;
         }
     } else {
         boost::system::error_code ec;
-        co_await boost::asio::async_read(socket_, boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await boost::asio::async_read(socket_, boost::asio::buffer(data, len),
+                                         boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         if (ec) {
             co_return false;
         }
     }
-    
+
     in_bytes_ += len;
     active_time_ = Utils::get_current_ms();
     co_return true;
@@ -220,20 +218,21 @@ boost::asio::awaitable<bool> TcpSocket::recv(uint8_t *data, size_t len, int32_t 
 
 boost::asio::awaitable<int32_t> TcpSocket::recv_some(uint8_t *data, size_t len, int32_t timeout_ms) {
     boost::system::error_code ec;
-    std::size_t s; 
+    std::size_t s;
     if (timeout_ms > 0) {
-        recv_timeout_timer_.expires_from_now(std::chrono::milliseconds(timeout_ms));
-        std::variant<std::size_t, std::monostate> results = co_await (
-            socket_.async_read_some(boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec)) ||
-            recv_timeout_timer_.async_wait(boost::asio::use_awaitable)
-        );
+        recv_timeout_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
+        std::variant<std::size_t, std::monostate> results =
+            co_await (socket_.async_read_some(boost::asio::buffer(data, len),
+                                              boost::asio::redirect_error(boost::asio::use_awaitable, ec)) ||
+                      recv_timeout_timer_.async_wait(boost::asio::use_awaitable));
 
-        if (results.index() == 1) {//超时
+        if (results.index() == 1) {  // 超时
             co_return -1;
         }
         s = std::get<0>(results);
     } else {
-        s = co_await socket_.async_read_some(boost::asio::buffer(data, len), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        s = co_await socket_.async_read_some(boost::asio::buffer(data, len),
+                                             boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     }
 
     if (ec) {
@@ -244,12 +243,8 @@ boost::asio::awaitable<int32_t> TcpSocket::recv_some(uint8_t *data, size_t len, 
     co_return s;
 }
 
-std::string TcpSocket::get_local_address() {
-    return socket_.local_endpoint().address().to_string();
-}
+std::string TcpSocket::get_local_address() { return socket_.local_endpoint().address().to_string(); }
 
-std::string TcpSocket::get_remote_address() {
-    return socket_.remote_endpoint().address().to_string();
-}
+std::string TcpSocket::get_remote_address() { return socket_.remote_endpoint().address().to_string(); }
 
-};
+};  // namespace mms

--- a/libs/base/network/tls_socket.cpp
+++ b/libs/base/network/tls_socket.cpp
@@ -1,42 +1,38 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/redirect_error.hpp>
-#include <boost/asio/experimental/awaitable_operators.hpp>
-#include <boost/asio/awaitable.hpp>
-
-#include <variant>
-#include <boost/asio/experimental/awaitable_operators.hpp>
-#include <boost/asio/redirect_error.hpp>
-#include <boost/asio/write.hpp>
-#include <boost/asio/read.hpp>
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-
 #include "tls_socket.hpp"
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/experimental/awaitable_operators.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/write.hpp>
+#include <variant>
+
 #include "server/tls/tls_session.h"
 
+
 using namespace mms;
-TlsSocket::TlsSocket(SocketInterfaceHandler *handler, std::shared_ptr<TlsSession> tls_session) :
-                                SocketInterface(handler),
-                                connect_timeout_timer_(tls_session->get_tcp_socket()->get_worker()->get_io_context()),     
-                                handshake_result_channel_(tls_session->get_tcp_socket()->get_worker()->get_io_context())
-{
+TlsSocket::TlsSocket(SocketInterfaceHandler *handler, std::shared_ptr<TlsSession> tls_session)
+    : SocketInterface(handler),
+      connect_timeout_timer_(tls_session->get_tcp_socket()->get_worker()->get_io_context()),
+      handshake_result_channel_(tls_session->get_tcp_socket()->get_worker()->get_io_context()) {
     encrypted_buf_ = new uint8_t[TLS_MAX_RECV_BUF];
     tls_session_ = tls_session;
 }
 
-TlsSocket::TlsSocket(SocketInterfaceHandler *handler, ThreadWorker *worker) : SocketInterface(handler),
-                                        connect_timeout_timer_(worker->get_io_context()),     
-                                        handshake_result_channel_(worker->get_io_context())
-{
-    auto tcp_socket = std::make_shared<TcpSocket>(this, boost::asio::ip::tcp::socket(worker->get_io_context()), worker);
-    tls_session_ = std::make_shared<TlsSession>(false, handler, nullptr, tcp_socket);//客户端模式
+TlsSocket::TlsSocket(SocketInterfaceHandler *handler, ThreadWorker *worker)
+    : SocketInterface(handler),
+      connect_timeout_timer_(worker->get_io_context()),
+      handshake_result_channel_(worker->get_io_context()) {
+    encrypted_buf_ = new uint8_t[TLS_MAX_RECV_BUF];
+    auto tcp_socket =
+        std::make_shared<TcpSocket>(this, boost::asio::ip::tcp::socket(worker->get_io_context()), worker);
+    tls_session_ = std::make_shared<TlsSession>(false, handler, nullptr, tcp_socket);  // 客户端模式
 }
 
-std::shared_ptr<TlsSession> TlsSocket::get_tls_session() {
-    return tls_session_;
-}
+std::shared_ptr<TlsSession> TlsSocket::get_tls_session() { return tls_session_; }
 
 TlsSocket::~TlsSocket() {
     spdlog::info("destroy TlsSocket");
@@ -45,14 +41,10 @@ TlsSocket::~TlsSocket() {
         ssl_ = nullptr;
     }
 
-    if (encrypted_buf_) {
-        delete[] encrypted_buf_;
-        encrypted_buf_ = nullptr;
-    }
     // bio_read_,bio_write_ 已经绑定了ssl_，所以不需要额外释放，否则内存异常
     if (ssl_ctx_) {
         SSL_CTX_free(ssl_ctx_);
-        ssl_ctx_= nullptr;
+        ssl_ctx_ = nullptr;
     }
 
     if (encrypted_buf_) {
@@ -106,8 +98,7 @@ void TlsSocket::close() {
     return;
 }
 
-boost::asio::awaitable<bool> TlsSocket::connect(const std::string & ip, uint16_t port, int32_t timeout_ms) {
-    ((void)timeout_ms);
+boost::asio::awaitable<bool> TlsSocket::connect(const std::string &ip, uint16_t port, int32_t timeout_ms) {
     ssl_ctx_ = SSL_CTX_new(TLSv1_2_method());
     if (!ssl_ctx_) {
         co_return false;
@@ -116,13 +107,13 @@ boost::asio::awaitable<bool> TlsSocket::connect(const std::string & ip, uint16_t
     SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_NONE, NULL);
 
     ssl_ = SSL_new(ssl_ctx_);
-    bio_read_  = BIO_new(BIO_s_mem());
+    bio_read_ = BIO_new(BIO_s_mem());
     bio_write_ = BIO_new(BIO_s_mem());
     SSL_set_bio(ssl_, bio_read_, bio_write_);
     SSL_set_connect_state(ssl_);
     SSL_set_mode(ssl_, SSL_MODE_AUTO_RETRY);
-    
-    //启动tls握手协程
+
+    // 启动tls握手协程
     auto tcp_sock = tls_session_->get_tcp_socket();
     if (!tcp_sock) {
         co_return false;
@@ -130,63 +121,69 @@ boost::asio::awaitable<bool> TlsSocket::connect(const std::string & ip, uint16_t
 
     if (!co_await tcp_sock->connect(ip, port, timeout_ms)) {
         SSL_CTX_free(ssl_ctx_);
-        ssl_ctx_= nullptr;
+        ssl_ctx_ = nullptr;
         co_return false;
     }
-    
+
     auto self(shared_from_this());
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self, tcp_sock, timeout_ms]()->boost::asio::awaitable<void> {
-        char* out_data = nullptr;
-        int32_t result = 0;
-        int ret;
-        while (!SSL_is_init_finished(ssl_)) {
-            ret = SSL_do_handshake(ssl_);
-            if (1 == ret) {
-                result = 0;//连接成功
-                break;
-            }
-
-            int reason = SSL_get_error(ssl_, ret);
-            if (reason != SSL_ERROR_WANT_READ && reason != SSL_ERROR_WANT_WRITE && reason != SSL_ERROR_NONE) {
-                result = -1;
-                break;
-            }
-
-            auto send_data_size = BIO_get_mem_data(bio_write_, &out_data);
-            if (send_data_size > 0) {
-                if (!co_await tcp_sock->send((uint8_t*)out_data, send_data_size)) {
-                    result = -2;
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self, tcp_sock, timeout_ms]() -> boost::asio::awaitable<void> {
+            char *out_data = nullptr;
+            int32_t result = 0;
+            int ret;
+            while (!SSL_is_init_finished(ssl_)) {
+                ret = SSL_do_handshake(ssl_);
+                if (1 == ret) {
+                    result = 0;  // 连接成功
                     break;
                 }
 
-                if (BIO_reset(bio_write_) != 1) {
-                    result = -3;
-                    break;
-                }
-            }
-
-            if (reason == SSL_ERROR_WANT_READ) {
-                int32_t len = co_await tcp_sock->recv_some(encrypted_buf_, TLS_MAX_RECV_BUF, timeout_ms);
-                if (len < 0) {
-                    result = -4;
+                int reason = SSL_get_error(ssl_, ret);
+                if (reason != SSL_ERROR_WANT_READ && reason != SSL_ERROR_WANT_WRITE &&
+                    reason != SSL_ERROR_NONE) {
+                    result = -1;
                     break;
                 }
 
-                int ret = BIO_write(bio_read_, encrypted_buf_, len);
-                if (ret <= 0) {
-                    result = -5;
-                    break;
+                auto send_data_size = BIO_get_mem_data(bio_write_, &out_data);
+                if (send_data_size > 0) {
+                    if (!co_await tcp_sock->send((uint8_t *)out_data, send_data_size)) {
+                        result = -2;
+                        break;
+                    }
+
+                    if (BIO_reset(bio_write_) != 1) {
+                        result = -3;
+                        break;
+                    }
+                }
+
+                if (reason == SSL_ERROR_WANT_READ) {
+                    int32_t len = co_await tcp_sock->recv_some(encrypted_buf_, TLS_MAX_RECV_BUF, timeout_ms);
+                    if (len < 0) {
+                        result = -4;
+                        break;
+                    }
+
+                    int ret = BIO_write(bio_read_, encrypted_buf_, len);
+                    if (ret <= 0) {
+                        result = -5;
+                        break;
+                    }
                 }
             }
-        }
-        
-        co_await handshake_result_channel_.async_send(boost::system::error_code{}, result, boost::asio::use_awaitable);
-        co_return;
-    }, boost::asio::detached);
+
+            co_await handshake_result_channel_.async_send(boost::system::error_code{}, result,
+                                                          boost::asio::use_awaitable);
+            co_return;
+        },
+        boost::asio::detached);
 
     boost::system::error_code ec;
     int res = 0;
-    res = co_await handshake_result_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    res = co_await handshake_result_channel_.async_receive(
+        boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     if (0 != res || ec) {
         co_return false;
     }
@@ -194,18 +191,18 @@ boost::asio::awaitable<bool> TlsSocket::connect(const std::string & ip, uint16_t
 }
 
 int TlsSocket::on_tls_ext_servername_cb(SSL *ssl, int *ad, void *arg) {
-    TlsSocket *this_ptr = (TlsSocket*)arg;
+    TlsSocket *this_ptr = (TlsSocket *)arg;
     return this_ptr->do_on_tls_ext_servername_cb(ssl, ad, arg);
 }
 
 int TlsSocket::do_on_tls_ext_servername_cb(SSL *ssl, int *ad, void *arg) {
     ((void)ad);
     ((void)arg);
-    if(ssl == NULL) {
+    if (ssl == NULL) {
         return SSL_TLSEXT_ERR_NOACK;
     }
 
-    const char * servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+    const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
     if (servername == NULL) {
         return SSL_TLSEXT_ERR_NOACK;
     }
@@ -236,78 +233,83 @@ boost::asio::awaitable<bool> TlsSocket::do_handshake(int32_t timeout_ms) {
         spdlog::error("no tls session");
         co_return false;
     }
-    
+
     SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_NONE, NULL);
     SSL_CTX_set_tlsext_servername_arg(ssl_ctx_, this);
     SSL_CTX_set_tlsext_servername_callback(ssl_ctx_, on_tls_ext_servername_cb);
 
     ssl_ = SSL_new(ssl_ctx_);
-    bio_read_  = BIO_new(BIO_s_mem());
+    bio_read_ = BIO_new(BIO_s_mem());
     bio_write_ = BIO_new(BIO_s_mem());
 
     SSL_set_bio(ssl_, bio_read_, bio_write_);
     SSL_set_accept_state(ssl_);
     SSL_set_mode(ssl_, SSL_MODE_ENABLE_PARTIAL_WRITE);
     auto self(shared_from_this());
-    //启动tls握手协程
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self, tcp_sock, timeout_ms]()->boost::asio::awaitable<void> {
-        char* out_data = nullptr;
-        int32_t result = 0;
-        
-        while (true) {
-            int32_t len = co_await tcp_sock->recv_some(encrypted_buf_, TLS_MAX_RECV_BUF, timeout_ms);
-            if (len < 0) {
-                result = -1;
-                break;
-            }
+    // 启动tls握手协程
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self, tcp_sock, timeout_ms]() -> boost::asio::awaitable<void> {
+            char *out_data = nullptr;
+            int32_t result = 0;
 
-            int ret = BIO_write(bio_read_, encrypted_buf_, len);
-            if (ret <= 0) {
-                result = -2;
-                break;
-            }
+            while (true) {
+                int32_t len = co_await tcp_sock->recv_some(encrypted_buf_, TLS_MAX_RECV_BUF, timeout_ms);
+                if (len < 0) {
+                    result = -1;
+                    break;
+                }
 
-            ret = SSL_do_handshake(ssl_);
-            if (ret == 1) {
-                // 连接成功
+                int ret = BIO_write(bio_read_, encrypted_buf_, len);
+                if (ret <= 0) {
+                    result = -2;
+                    break;
+                }
+
+                ret = SSL_do_handshake(ssl_);
+                if (ret == 1) {
+                    // 连接成功
+                    int r1 = SSL_get_error(ssl_, ret);
+                    if (r1 != SSL_ERROR_WANT_READ && r1 != SSL_ERROR_WANT_WRITE && r1 != SSL_ERROR_NONE) {
+                        result = -3;
+                        break;
+                    }
+                    // 判断是否有数据要发送
+                    auto send_data_size = BIO_get_mem_data(bio_write_, &out_data);
+                    if (send_data_size > 0) {
+                        co_await tcp_sock->send((uint8_t *)out_data, send_data_size, timeout_ms);
+                        if (BIO_reset(bio_write_) != 1) {
+                            result = -4;
+                            break;
+                        }
+                    }
+                    break;
+                }
+                // 失败了，但如果是READ/WRITE则不算失败
                 int r1 = SSL_get_error(ssl_, ret);
                 if (r1 != SSL_ERROR_WANT_READ && r1 != SSL_ERROR_WANT_WRITE && r1 != SSL_ERROR_NONE) {
-                    result = -3;
+                    result = -5;
                     break;
                 }
                 // 判断是否有数据要发送
                 auto send_data_size = BIO_get_mem_data(bio_write_, &out_data);
                 if (send_data_size > 0) {
-                    co_await tcp_sock->send((uint8_t*)out_data, send_data_size, timeout_ms);
+                    co_await tcp_sock->send((uint8_t *)out_data, send_data_size, timeout_ms);
                     if (BIO_reset(bio_write_) != 1) {
-                        result = -4;
+                        result = -6;
                         break;
                     }
                 }
-                break;
-            } 
-            // 失败了，但如果是READ/WRITE则不算失败
-            int r1 = SSL_get_error(ssl_, ret);
-            if (r1 != SSL_ERROR_WANT_READ && r1 != SSL_ERROR_WANT_WRITE && r1 != SSL_ERROR_NONE) {
-                result = -5;
-                break;
             }
-            // 判断是否有数据要发送
-            auto send_data_size = BIO_get_mem_data(bio_write_, &out_data);
-            if (send_data_size > 0) {
-                co_await tcp_sock->send((uint8_t*)out_data, send_data_size, timeout_ms);
-                if (BIO_reset(bio_write_) != 1) {
-                    result = -6;
-                    break;
-                }
-            }
-        }
-        co_await handshake_result_channel_.async_send(boost::system::error_code{}, result, boost::asio::use_awaitable);
-        co_return;
-    }, boost::asio::detached);
-    
+            co_await handshake_result_channel_.async_send(boost::system::error_code{}, result,
+                                                          boost::asio::use_awaitable);
+            co_return;
+        },
+        boost::asio::detached);
+
     boost::system::error_code ec;
-    auto res = co_await handshake_result_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    auto res = co_await handshake_result_channel_.async_receive(
+        boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     if (res == 0) {
         co_return true;
     } else {
@@ -315,8 +317,7 @@ boost::asio::awaitable<bool> TlsSocket::do_handshake(int32_t timeout_ms) {
     }
 }
 
-boost::asio::awaitable<int32_t> TlsSocket::recv_some(uint8_t *data, size_t len, int32_t timeout_ms)
-{
+boost::asio::awaitable<int32_t> TlsSocket::recv_some(uint8_t *data, size_t len, int32_t timeout_ms) {
     auto tcp_sock = tls_session_->get_tcp_socket();
     if (!tcp_sock) {
         co_return -1;
@@ -324,9 +325,9 @@ boost::asio::awaitable<int32_t> TlsSocket::recv_some(uint8_t *data, size_t len, 
 
     while (true) {
         int r0 = SSL_read(ssl_, data, len);
-        if (r0 == 0) {//对端关闭连接
+        if (r0 == 0) {  // 对端关闭连接
             co_return -1;
-        } else if (r0 > 0) {//大于0，是字节数
+        } else if (r0 > 0) {  // 大于0，是字节数
             co_return r0;
         }
 
@@ -346,15 +347,14 @@ boost::asio::awaitable<int32_t> TlsSocket::recv_some(uint8_t *data, size_t len, 
     co_return -4;
 }
 
-boost::asio::awaitable<bool> TlsSocket::send(const uint8_t *data, size_t len, int32_t timeout_ms)
-{
+boost::asio::awaitable<bool> TlsSocket::send(const uint8_t *data, size_t len, int32_t timeout_ms) {
     auto tcp_sock = tls_session_->get_tcp_socket();
     if (!tcp_sock) {
         co_return false;
     }
 
     size_t data_pos = 0;
-    char* out_data = nullptr;
+    char *out_data = nullptr;
     int send_data_size;
     while (data_pos < len) {
         int r0 = SSL_write(ssl_, data + data_pos, len - data_pos);
@@ -372,7 +372,7 @@ boost::asio::awaitable<bool> TlsSocket::send(const uint8_t *data, size_t len, in
         // 判断是否有数据要发送
         send_data_size = BIO_get_mem_data(bio_write_, &out_data);
         if (send_data_size > 0) {
-            if (!co_await tcp_sock->send((uint8_t*)out_data, send_data_size, timeout_ms)) {
+            if (!co_await tcp_sock->send((uint8_t *)out_data, send_data_size, timeout_ms)) {
                 co_return false;
             }
 
@@ -384,25 +384,27 @@ boost::asio::awaitable<bool> TlsSocket::send(const uint8_t *data, size_t len, in
     co_return true;
 }
 
-boost::asio::awaitable<bool> TlsSocket::send(std::vector<boost::asio::const_buffer> & bufs, int32_t timeout_ms) {
+boost::asio::awaitable<bool> TlsSocket::send(std::vector<boost::asio::const_buffer> &bufs,
+                                             int32_t timeout_ms) {
     auto tcp_sock = tls_session_->get_tcp_socket();
     if (!tcp_sock) {
         co_return false;
     }
 
-    char* out_data = nullptr;
+    char *out_data = nullptr;
     int send_data_size;
     int32_t curr_buf_index = 0;
     size_t curr_buf_offset = 0;
     int32_t len = 0;
-    for (auto & buf : bufs) {
+    for (auto &buf : bufs) {
         len += buf.size();
     }
     int32_t sended_bytes = 0;
     int r0;
     while (sended_bytes < len) {
         while (sended_bytes < len) {
-            r0 = SSL_write(ssl_, (char*)(bufs[curr_buf_index].data()) + curr_buf_offset, bufs[curr_buf_index].size() - curr_buf_offset);
+            r0 = SSL_write(ssl_, (char *)(bufs[curr_buf_index].data()) + curr_buf_offset,
+                           bufs[curr_buf_index].size() - curr_buf_offset);
             if (r0 <= 0) {
                 int r1 = SSL_get_error(ssl_, r0);
                 if (r1 != SSL_ERROR_NONE && r1 != SSL_ERROR_WANT_WRITE) {
@@ -418,7 +420,7 @@ boost::asio::awaitable<bool> TlsSocket::send(std::vector<boost::asio::const_buff
                 }
             }
         }
-        
+
         int r1 = SSL_get_error(ssl_, r0);
         if (r1 != SSL_ERROR_NONE && r1 != SSL_ERROR_WANT_WRITE) {
             co_return false;
@@ -427,7 +429,7 @@ boost::asio::awaitable<bool> TlsSocket::send(std::vector<boost::asio::const_buff
         // 判断是否有数据要发送
         send_data_size = BIO_get_mem_data(bio_write_, &out_data);
         if (send_data_size > 0) {
-            if (!co_await tcp_sock->send((uint8_t*)out_data, send_data_size, timeout_ms)) {
+            if (!co_await tcp_sock->send((uint8_t *)out_data, send_data_size, timeout_ms)) {
                 co_return false;
             }
 
@@ -439,8 +441,7 @@ boost::asio::awaitable<bool> TlsSocket::send(std::vector<boost::asio::const_buff
     co_return true;
 }
 
-boost::asio::awaitable<bool> TlsSocket::recv(uint8_t *data, size_t len, int32_t timeout_ms)
-{
+boost::asio::awaitable<bool> TlsSocket::recv(uint8_t *data, size_t len, int32_t timeout_ms) {
     auto tcp_sock = tls_session_->get_tcp_socket();
     if (!tcp_sock) {
         co_return false;
@@ -449,9 +450,9 @@ boost::asio::awaitable<bool> TlsSocket::recv(uint8_t *data, size_t len, int32_t 
     size_t data_pos = 0;
     while (data_pos < len) {
         int r0 = SSL_read(ssl_, data + data_pos, len - data_pos);
-        if (r0 == 0) {//对端关闭连接
+        if (r0 == 0) {  // 对端关闭连接
             co_return false;
-        } else if (r0 > 0) {//大于0，是字节数
+        } else if (r0 > 0) {  // 大于0，是字节数
             data_pos += r0;
             continue;
         }

--- a/libs/base/network/tls_socket.hpp
+++ b/libs/base/network/tls_socket.hpp
@@ -1,28 +1,29 @@
 #pragma once
-#include "tcp_socket.hpp"
-#include <vector>
-#include <memory>
-#include <unordered_map>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/array.hpp>
 #include <array>
+#include <boost/array.hpp>
 #include <boost/asio/experimental/channel.hpp>
 #include <boost/asio/experimental/concurrent_channel.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/shared_ptr.hpp>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
-#include "openssl/ssl.h"
-#include "openssl/bio.h"
-#include "base/thread/thread_worker.hpp"
 #include "base/network/tcp_socket.hpp"
+#include "base/thread/thread_worker.hpp"
+#include "openssl/bio.h"
+#include "openssl/ssl.h"
+#include "tcp_socket.hpp"
+
 
 namespace mms {
-#define TLS_MAX_RECV_BUF (1024*1024)
+#define TLS_MAX_RECV_BUF (2 * 1024 * 1024)
 class TlsSocket;
 class TlsSession;
 
 class TlsServerNameHandler {
 public:
-    virtual std::shared_ptr<SSL_CTX> on_tls_ext_servername(const std::string & doamin_name) = 0;
+    virtual std::shared_ptr<SSL_CTX> on_tls_ext_servername(const std::string &doamin_name) = 0;
 };
 
 class TlsSocket : public SocketInterface, public SocketInterfaceHandler {
@@ -40,29 +41,34 @@ public:
     void open() override;
     void close() override;
 
-    boost::asio::awaitable<bool> connect(const std::string & ip, uint16_t port, int32_t timeout_ms = 0) override;
+    boost::asio::awaitable<bool> connect(const std::string &ip, uint16_t port,
+                                         int32_t timeout_ms = 0) override;
     boost::asio::awaitable<int32_t> recv_some(uint8_t *data, size_t len, int32_t timeout_ms = 0) override;
     boost::asio::awaitable<bool> send(const uint8_t *data, size_t len, int32_t timeout_ms = 0) override;
-    boost::asio::awaitable<bool> send(std::vector<boost::asio::const_buffer> & bufs, int32_t timeout_ms = 0) override;
+    boost::asio::awaitable<bool> send(std::vector<boost::asio::const_buffer> &bufs,
+                                      int32_t timeout_ms = 0) override;
     boost::asio::awaitable<bool> recv(uint8_t *data, size_t len, int32_t timeout_ms = 0) override;
     boost::asio::awaitable<bool> do_handshake(int32_t timeout_ms = 1000);
+
 private:
     void on_socket_open(std::shared_ptr<SocketInterface> tcp_sock) override;
     void on_socket_close(std::shared_ptr<SocketInterface> tcp_sock) override;
-    
+
     boost::asio::steady_timer connect_timeout_timer_;
     static int on_tls_ext_servername_cb(SSL *ssl, int *ad, void *arg);
     int do_on_tls_ext_servername_cb(SSL *ssl, int *ad, void *arg);
-    boost::asio::experimental::concurrent_channel<void(boost::system::error_code, int32_t)> handshake_result_channel_;
+    boost::asio::experimental::concurrent_channel<void(boost::system::error_code, int32_t)>
+        handshake_result_channel_;
     SSL *ssl_ = nullptr;
-    BIO *bio_read_    = nullptr;
-    BIO *bio_write_   = nullptr;
+    BIO *bio_read_ = nullptr;
+    BIO *bio_write_ = nullptr;
 
     uint8_t *encrypted_buf_ = nullptr;
     SSL_CTX *ssl_ctx_ = nullptr;
     std::shared_ptr<SSL_CTX> use_ssl_ctx_;
+
 private:
-    TlsServerNameHandler * server_name_handler_ = nullptr;
+    TlsServerNameHandler *server_name_handler_ = nullptr;
     std::shared_ptr<TlsSession> tls_session_;
 };
-};
+};  // namespace mms

--- a/libs/base/network/udp_socket.cpp
+++ b/libs/base/network/udp_socket.cpp
@@ -1,39 +1,47 @@
 #include "udp_socket.hpp"
 using namespace mms;
-UdpSocket::UdpSocket(UdpSocketHandler *handler, std::unique_ptr<boost::asio::ip::udp::socket> sock) : handler_(handler), sock_(std::move(sock)) {
+UdpSocket::UdpSocket(UdpSocketHandler *handler,
+                     std::unique_ptr<boost::asio::ip::udp::socket> sock)
+    : handler_(handler), sock_(std::move(sock)) {}
 
+UdpSocket::UdpSocket(std::unique_ptr<boost::asio::ip::udp::socket> sock)
+    : sock_(std::move(sock)) {}
+
+boost::asio::awaitable<bool>
+UdpSocket::send_to(uint8_t *data, size_t len,
+                   const boost::asio::ip::udp::endpoint &remote_ep) {
+  boost::system::error_code ec;
+  auto size = co_await sock_->async_send_to(
+      boost::asio::buffer(data, len), remote_ep,
+      boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+  if (ec || size != len) {
+    co_return false;
+  }
+  co_return true;
 }
 
-UdpSocket::UdpSocket(std::unique_ptr<boost::asio::ip::udp::socket> sock) : sock_(std::move(sock)) {
-
+boost::asio::awaitable<int32_t>
+UdpSocket::recv_from(uint8_t *data, size_t len,
+                     boost::asio::ip::udp::endpoint &remote_ep) {
+  boost::system::error_code ec;
+  auto size = co_await sock_->async_receive_from(
+      boost::asio::buffer(data, len), remote_ep,
+      boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+  if (ec) {
+    co_return -1;
+  }
+  co_return size;
 }
 
-boost::asio::awaitable<bool> UdpSocket::send_to(uint8_t *data, size_t len, const boost::asio::ip::udp::endpoint & remote_ep) {
-    boost::system::error_code ec;
-    auto size = co_await sock_->async_send_to(boost::asio::buffer(data, len), remote_ep, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-    if (ec || size != len) {
-        co_return false;
-    }
-    co_return true;
-}
-
-boost::asio::awaitable<int32_t> UdpSocket::recv_from(uint8_t *data, size_t len, boost::asio::ip::udp::endpoint & remote_ep) {
-    boost::system::error_code ec;
-    auto size = co_await sock_->async_receive_from(boost::asio::buffer(data, len), remote_ep, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-    if (ec) {
-        co_return -1;
-    }
-    co_return size;
-}
-
-bool UdpSocket::bind(const std::string & ip, uint16_t port) {
-    boost::asio::ip::udp::endpoint local_ep(boost::asio::ip::address::from_string(ip), port);
-    sock_->open(boost::asio::ip::udp::v4());
-    sock_->set_option(boost::asio::ip::udp::socket::reuse_address(true));
-    boost::system::error_code ec;
-    sock_->bind(local_ep, ec);
-    if (ec) {
-        return false;
-    }
-    return true;
+bool UdpSocket::bind(const std::string &ip, uint16_t port) {
+  boost::asio::ip::udp::endpoint local_ep(boost::asio::ip::make_address(ip),
+                                          port);
+  sock_->open(boost::asio::ip::udp::v4());
+  sock_->set_option(boost::asio::ip::udp::socket::reuse_address(true));
+  boost::system::error_code ec;
+  sock_->bind(local_ep, ec);
+  if (ec) {
+    return false;
+  }
+  return true;
 }

--- a/libs/base/thread/thread_worker.cpp
+++ b/libs/base/thread/thread_worker.cpp
@@ -2,30 +2,21 @@
 
 #include <sys/prctl.h>
 
+#include <atomic>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/system/error_code.hpp>
 #include <functional>
 #include <thread>
-#include <atomic>
-
-#include <boost/system/error_code.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 using namespace mms;
 
-ThreadWorker::ThreadWorker() : work_guard_(boost::asio::make_work_guard(io_context_)) {
-    running_ = false;
-}
+ThreadWorker::ThreadWorker() : work_guard_(boost::asio::make_work_guard(io_context_)) { running_ = false; }
 
-ThreadWorker::~ThreadWorker() {
-
-}
+ThreadWorker::~ThreadWorker() {}
 // 设置在哪个cpu核心上运行
-void ThreadWorker::set_cpu_core(int cpu_core) {
-    cpu_core_ = cpu_core;
-}
+void ThreadWorker::set_cpu_core(int cpu_core) { cpu_core_ = cpu_core; }
 
-int ThreadWorker::get_cpu_core() {
-    return cpu_core_;
-}
+int ThreadWorker::get_cpu_core() { return cpu_core_; }
 
 void ThreadWorker::start() {
     if (running_) {
@@ -42,9 +33,8 @@ void ThreadWorker::work() {
     if (pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask) < 0) {
         // print error log
     } else {
-
     }
-    
+
     io_context_.run();
 }
 
@@ -58,45 +48,29 @@ void ThreadWorker::stop() {
     thread_.join();
 }
 
-boost::asio::io_context & ThreadWorker::get_io_context() {
-    return io_context_;
-}
+boost::asio::io_context &ThreadWorker::get_io_context() { return io_context_; }
 
+ThreadWorker::Event::Event(ThreadWorker *worker, const std::function<void(Event *ev)> &f)
+    : worker_(worker), f_(f), timer_(worker->get_io_context()) {}
 
-ThreadWorker::Event::Event(ThreadWorker *worker, const std::function<void(Event *ev)> &f) : worker_(worker), f_(f), timer_(worker->get_io_context())
-{
-}
+ThreadWorker::Event::~Event() { timer_.cancel(); }
 
-ThreadWorker::Event::~Event() 
-{
-    timer_.cancel();
-}
-
-void ThreadWorker::Event::invoke_after(uint32_t ms) 
-{
+void ThreadWorker::Event::invoke_after(uint32_t ms) {
     timer_.expires_from_now(boost::posix_time::milliseconds(ms));
-    timer_.async_wait([this](const boost::system::error_code & ec) {
+    timer_.async_wait([this](const boost::system::error_code &ec) {
         if (ec != boost::asio::error::operation_aborted) {
             f_(this);
         }
     });
 }
 
-ThreadWorker *ThreadWorker::Event::get_worker() 
-{
-    return worker_;
-}
+ThreadWorker *ThreadWorker::Event::get_worker() { return worker_; }
 
-ThreadWorker::Event* ThreadWorker::create_event(const std::function<void(Event* ev)> &f)
-{
-    Event* ev = new Event(this, f);
+ThreadWorker::Event *ThreadWorker::create_event(const std::function<void(Event *ev)> &f) {
+    Event *ev = new Event(this, f);
     return ev;
 }
 
-
-void ThreadWorker::remove_event(Event *ev) 
-{
-    dispatch([ev, this]() {
-        delete ev;
-    });
+void ThreadWorker::remove_event(Event *ev) {
+    dispatch([ev, this]() { delete ev; });
 }

--- a/libs/base/thread/thread_worker.hpp
+++ b/libs/base/thread/thread_worker.hpp
@@ -1,13 +1,14 @@
-
 #pragma once
 
-#include <memory>
-#include <functional>
-#include <thread>
 #include <atomic>
-
 #include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/dispatch.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <functional>
+#include <memory>
+#include <thread>
+
 
 namespace mms {
 class ThreadWorker;
@@ -20,14 +21,14 @@ public:
     void set_cpu_core(int cpu_core);
     int get_cpu_core();
 
-    template<typename F, typename ...ARGS>
+    template <typename F, typename... ARGS>
     void post(F &&f, ARGS &&...args) {
-        io_context_.post(std::bind(f, std::forward<ARGS>(args)...));
+        boost::asio::post(io_context_, std::bind(f, std::forward<ARGS>(args)...));
     }
 
-    template<typename F, typename ...ARGS>
+    template <typename F, typename... ARGS>
     void dispatch(F &&f, ARGS &&...args) {
-        io_context_.dispatch(std::bind(f, std::forward<ARGS>(args)...));
+        boost::asio::dispatch(io_context_, std::bind(f, std::forward<ARGS>(args)...));
     }
 
     class Event {
@@ -36,19 +37,21 @@ public:
         ~Event();
         void invoke_after(uint32_t ms);
         ThreadWorker *get_worker();
+
     private:
         ThreadWorker *worker_;
         std::function<void(Event *ev)> f_;
         boost::asio::deadline_timer timer_;
     };
 
-    Event* create_event(const std::function<void(Event* ev)> &f);
+    Event *create_event(const std::function<void(Event *ev)> &f);
     void remove_event(Event *ev);
 
     void start();
     void work();
     void stop();
-    boost::asio::io_context & get_io_context();
+    boost::asio::io_context &get_io_context();
+
 private:
     int cpu_core_;
     boost::asio::io_context io_context_;
@@ -57,4 +60,4 @@ private:
     std::atomic_bool running_;
 };
 
-};
+};  // namespace mms

--- a/libs/base/xmake.lua
+++ b/libs/base/xmake.lua
@@ -1,0 +1,5 @@
+target("base", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_packages("boost", "jsoncpp", "openssl3", "spdlog", { public = true })
+end)

--- a/libs/codec/xmake.lua
+++ b/libs/codec/xmake.lua
@@ -1,0 +1,7 @@
+target("codec", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", {public = true})
+    add_deps("base")
+    add_packages("faac","faad2","opus")
+end)

--- a/libs/protocol/http/xmake.lua
+++ b/libs/protocol/http/xmake.lua
@@ -1,0 +1,6 @@
+target("protocol_http", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_deps("base")
+    add_includedirs(".", { public = true })
+end)

--- a/libs/protocol/mp4/xmake.lua
+++ b/libs/protocol/mp4/xmake.lua
@@ -1,0 +1,5 @@
+target("protocol_mp4", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_deps("base")
+end)

--- a/libs/protocol/rtmp/amf0/amf0_ecma_array.cpp
+++ b/libs/protocol/rtmp/amf0/amf0_ecma_array.cpp
@@ -1,37 +1,38 @@
 #include "amf0_ecma_array.hpp"
+
 #include "amf0_object.hpp"
+
 using namespace mms;
 
 Json::Value Amf0EcmaArray::to_json() {
     Json::Value root;
-    for (auto & p : properties_) {
-        switch(p.second->get_type()) {
+    for (auto &p : properties_) {
+        switch (p.second->get_type()) {
             case NUMBER_MARKER: {
-                root[p.first] = ((Amf0Number*)p.second)->get_value();
+                root[p.first] = ((Amf0Number *)p.second)->get_value();
                 break;
             }
             case BOOLEAN_MARKER: {
-                root[p.first] = ((Amf0Boolean*)p.second)->get_value();
+                root[p.first] = ((Amf0Boolean *)p.second)->get_value();
                 break;
             }
             case STRING_MARKER: {
-                root[p.first] = ((Amf0String*)p.second)->get_value();
+                root[p.first] = ((Amf0String *)p.second)->get_value();
                 break;
             }
             case OBJECT_MARKER: {
-                root[p.first] = ((Amf0Object*)p.second)->to_json();
+                root[p.first] = ((Amf0Object *)p.second)->to_json();
                 break;
             }
             case NULL_MARKER: {
-                root[p.first] = nullptr;
+                root[p.first] = Json::Value::null;
                 break;
             }
             case UNDEFINED_MARKER: {
                 root[p.first] = "undefined";
                 break;
             }
-            default : {
-                
+            default: {
             }
         }
     }
@@ -41,7 +42,6 @@ Json::Value Amf0EcmaArray::to_json() {
 int32_t Amf0EcmaArray::decode(const uint8_t *data, size_t len) {
     auto buf_start = data;
     if (len < 1) {
-        
         return -1;
     }
     auto marker = *data;
@@ -56,7 +56,7 @@ int32_t Amf0EcmaArray::decode(const uint8_t *data, size_t len) {
     }
 
     int32_t count = 0;
-    char *p = (char*)&count;
+    char *p = (char *)&count;
     p[0] = data[3];
     p[1] = data[2];
     p[2] = data[1];
@@ -72,7 +72,7 @@ int32_t Amf0EcmaArray::decode(const uint8_t *data, size_t len) {
             return -4;
         }
         uint16_t key_len = 0;
-        char *p = (char*)&key_len;
+        char *p = (char *)&key_len;
         p[0] = data[1];
         p[1] = data[0];
 
@@ -91,35 +91,35 @@ int32_t Amf0EcmaArray::decode(const uint8_t *data, size_t len) {
         if (len < 1) {
             return -6;
         }
-    
+
         AMF0_MARKER_TYPE marker = (AMF0_MARKER_TYPE)(*data);
         Amf0Data *value = nullptr;
-        switch(marker) {
-            case NUMBER_MARKER:{
+        switch (marker) {
+            case NUMBER_MARKER: {
                 value = new Amf0Number;
                 break;
             }
-            case BOOLEAN_MARKER:{
+            case BOOLEAN_MARKER: {
                 value = new Amf0Boolean;
                 break;
             }
-            case STRING_MARKER:{
+            case STRING_MARKER: {
                 value = new Amf0String;
                 break;
             }
-            case NULL_MARKER:{
+            case NULL_MARKER: {
                 value = new Amf0Null;
                 break;
             }
-            case UNDEFINED_MARKER:{
+            case UNDEFINED_MARKER: {
                 value = new Amf0Undefined;
                 break;
             }
-            case OBJECT_MARKER:{
+            case OBJECT_MARKER: {
                 value = new Amf0Object;
                 break;
             }
-            default : {
+            default: {
                 return -7;
             }
         }
@@ -160,13 +160,13 @@ int32_t Amf0EcmaArray::encode(uint8_t *buf, size_t len) const {
     *data = OBJECT_MARKER;
     data++;
     len--;
-    
-    for (auto & p : properties_) {
+
+    for (auto &p : properties_) {
         // key
         if (len < 2) {
             return -3;
         }
-        *(uint16_t*)data = htons(p.first.size());
+        *(uint16_t *)data = htons(p.first.size());
         data += 2;
         len -= 2;
 

--- a/libs/protocol/rtmp/amf0/amf0_object.cpp
+++ b/libs/protocol/rtmp/amf0/amf0_object.cpp
@@ -1,22 +1,21 @@
-#include <iostream>
-
 #include "amf0_object.hpp"
 
+#include <iostream>
+
 #include "amf0_boolean.hpp"
+#include "amf0_date.hpp"
 #include "amf0_def.hpp"
 #include "amf0_null.hpp"
 #include "amf0_number.hpp"
 #include "amf0_obj_end.hpp"
-#include "amf0_string.hpp"
-#include "amf0_undefined.hpp"
 #include "amf0_reference.hpp"
 #include "amf0_strict_array.hpp"
-#include "amf0_date.hpp"
+#include "amf0_string.hpp"
+#include "amf0_undefined.hpp"
 
 namespace mms {
-int32_t Amf0Object::decode(const uint8_t* data, size_t len)
-{
-    uint8_t *data_start = (uint8_t*)data;
+int32_t Amf0Object::decode(const uint8_t *data, size_t len) {
+    uint8_t *data_start = (uint8_t *)data;
     Amf0ObjEnd obj_end;
     int32_t consumed = 0;
 
@@ -34,7 +33,7 @@ int32_t Amf0Object::decode(const uint8_t* data, size_t len)
 
     while (len > 0) {
         consumed = obj_end.decode(data, len);
-        if (consumed > 0) { //is obj end
+        if (consumed > 0) {  // is obj end
             len -= consumed;
             data += consumed;
             return data - data_start;
@@ -44,7 +43,7 @@ int32_t Amf0Object::decode(const uint8_t* data, size_t len)
             return -3;
         }
         uint16_t key_len = 0;
-        key_len = ntohs(*(uint16_t*)data);
+        key_len = ntohs(*(uint16_t *)data);
 
         data += 2;
         len -= 2;
@@ -60,47 +59,47 @@ int32_t Amf0Object::decode(const uint8_t* data, size_t len)
         len -= key_len;
         // read data
         marker = (AMF0_MARKER_TYPE)data[0];
-        Amf0Data* value = nullptr;
+        Amf0Data *value = nullptr;
         switch (marker) {
-        case NUMBER_MARKER: {
-            value = new Amf0Number;
-            break;
-        }
-        case BOOLEAN_MARKER: {
-            value = new Amf0Boolean;
-            break;
-        }
-        case STRING_MARKER: {
-            value = new Amf0String;
-            break;
-        }
-        case OBJECT_MARKER: {
-            value = new Amf0Object;
-            break;
-        }
-        case NULL_MARKER: {
-            value = new Amf0Null;
-            break;
-        }
-        case UNDEFINED_MARKER: {
-            value = new Amf0Undefined;
-            break;
-        }
-        case REFERENCE_MARKER: {
-            value = new Amf0Reference;
-            break;
-        }
-        case STRICT_ARRAY_MARKER: {
-            value = new Amf0StrictArray;
-            break;
-        }
-        case DATE_MARKER: {
-            value = new Amf0Date;
-            break;
-        }
-        default: {
-            return -5;
-        }
+            case NUMBER_MARKER: {
+                value = new Amf0Number;
+                break;
+            }
+            case BOOLEAN_MARKER: {
+                value = new Amf0Boolean;
+                break;
+            }
+            case STRING_MARKER: {
+                value = new Amf0String;
+                break;
+            }
+            case OBJECT_MARKER: {
+                value = new Amf0Object;
+                break;
+            }
+            case NULL_MARKER: {
+                value = new Amf0Null;
+                break;
+            }
+            case UNDEFINED_MARKER: {
+                value = new Amf0Undefined;
+                break;
+            }
+            case REFERENCE_MARKER: {
+                value = new Amf0Reference;
+                break;
+            }
+            case STRICT_ARRAY_MARKER: {
+                value = new Amf0StrictArray;
+                break;
+            }
+            case DATE_MARKER: {
+                value = new Amf0Date;
+                break;
+            }
+            default: {
+                return -5;
+            }
         }
 
         if (value != nullptr) {
@@ -133,13 +132,13 @@ int32_t Amf0Object::encode(uint8_t *buf, size_t len) const {
     *data = OBJECT_MARKER;
     data++;
     len--;
-    
-    for (auto & p : properties_) {
+
+    for (auto &p : properties_) {
         // key
         if (len < 2) {
             return -3;
         }
-        *(uint16_t*)data = htons(p.first.size());
+        *(uint16_t *)data = htons(p.first.size());
         data += 2;
         len -= 2;
 
@@ -167,38 +166,37 @@ int32_t Amf0Object::encode(uint8_t *buf, size_t len) const {
 
 Json::Value Amf0Object::to_json() {
     Json::Value root;
-    for (auto & p : properties_) {
-        switch(p.second->get_type()) {
+    for (auto &p : properties_) {
+        switch (p.second->get_type()) {
             case NUMBER_MARKER: {
-                root[p.first] = ((Amf0Number*)p.second)->get_value();
+                root[p.first] = ((Amf0Number *)p.second)->get_value();
                 break;
             }
             case BOOLEAN_MARKER: {
-                root[p.first] = ((Amf0Boolean*)p.second)->get_value();
+                root[p.first] = ((Amf0Boolean *)p.second)->get_value();
                 break;
             }
             case STRING_MARKER: {
-                root[p.first] = ((Amf0String*)p.second)->get_value();
+                root[p.first] = ((Amf0String *)p.second)->get_value();
                 break;
             }
             case OBJECT_MARKER: {
-                root[p.first] = ((Amf0Object*)p.second)->to_json();
+                root[p.first] = ((Amf0Object *)p.second)->to_json();
                 break;
             }
             case NULL_MARKER: {
-                root[p.first] = nullptr;
+                root[p.first] = Json::Value::null;
                 break;
             }
             case UNDEFINED_MARKER: {
                 root[p.first] = "undefined";
                 break;
             }
-            default : {
-                
+            default: {
             }
         }
     }
     return root;
 }
 
-};
+};  // namespace mms

--- a/libs/protocol/rtmp/xmake.lua
+++ b/libs/protocol/rtmp/xmake.lua
@@ -1,0 +1,7 @@
+target("protocol_rtmp", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", { public = true })
+    add_includedirs("..", { public = true })
+    add_deps("base")
+end)

--- a/libs/protocol/rtp/xmake.lua
+++ b/libs/protocol/rtp/xmake.lua
@@ -1,0 +1,8 @@
+target("protocol_rtp", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", { public = true })
+    add_deps("base")
+    -- add_deps("codec_h264", "codec_hevc")
+end)
+

--- a/libs/protocol/rtsp/xmake.lua
+++ b/libs/protocol/rtsp/xmake.lua
@@ -1,0 +1,6 @@
+target("protocol_rtsp", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", { public = true })
+    add_deps("base")
+end)

--- a/libs/protocol/sdp/xmake.lua
+++ b/libs/protocol/sdp/xmake.lua
@@ -1,0 +1,6 @@
+target("protocol_sdp", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", {public = true})
+    add_deps("base")
+end)

--- a/libs/protocol/ts/xmake.lua
+++ b/libs/protocol/ts/xmake.lua
@@ -1,0 +1,6 @@
+target("protocol_ts", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", { public = true })
+    add_deps("base")
+end)

--- a/libs/protocol/xmake.lua
+++ b/libs/protocol/xmake.lua
@@ -1,0 +1,7 @@
+includes("http")
+includes("mp4")
+includes("rtmp")
+includes("rtp")
+includes("rtsp")
+includes("sdp")
+includes("ts")

--- a/libs/sdk/http/xmake.lua
+++ b/libs/sdk/http/xmake.lua
@@ -1,6 +1,7 @@
 target("sdk_http", function () 
     set_kind("static")
     add_files("**.cpp")
+    add_includedirs(".", { public = true })
     add_deps("base", "protocol_http")
     add_packages("spdlog")
 end)

--- a/libs/sdk/http/xmake.lua
+++ b/libs/sdk/http/xmake.lua
@@ -1,0 +1,6 @@
+target("sdk_http", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_deps("base", "protocol_http")
+    add_packages("spdlog")
+end)

--- a/libs/server/tcp/tcp_server.cpp
+++ b/libs/server/tcp/tcp_server.cpp
@@ -1,63 +1,66 @@
 #include "tcp_server.hpp"
-#include "spdlog/spdlog.h"
+
 #include <string>
+
+#include "spdlog/spdlog.h"
 
 using namespace mms;
 
-TcpServer::TcpServer(SocketInterfaceHandler *tcp_handler, ThreadWorker *worker):worker_(worker), tcp_handler_(tcp_handler) {
+TcpServer::TcpServer(SocketInterfaceHandler *tcp_handler, ThreadWorker *worker)
+    : worker_(worker), tcp_handler_(tcp_handler) {}
 
-}
+TcpServer::~TcpServer() {}
 
-TcpServer::~TcpServer() {
-
-}
-
-int32_t TcpServer::start_listen(uint16_t port, const std::string & addr) {
+int32_t TcpServer::start_listen(uint16_t port, const std::string &addr) {
     if (!worker_) {
         return -1;
     }
 
     running_ = true;
     port_ = port;
-    boost::asio::co_spawn(worker_->get_io_context(), ([port, addr, this]()->boost::asio::awaitable<void> {
-        boost::asio::ip::tcp::endpoint endpoint;
-        endpoint.port(port);
-        if (!addr.empty()) {
-            endpoint.address(boost::asio::ip::address::from_string(addr));
-        } else {
-            endpoint.address(boost::asio::ip::address::from_string("0.0.0.0"));
-        }
-
-        acceptor_ = boost::make_shared<boost::asio::ip::tcp::acceptor>(worker_->get_io_context(), endpoint);
-        acceptor_->set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
-        while(1) {
-            boost::system::error_code ec;
-            auto worker = thread_pool_inst::get_mutable_instance().get_worker(-1);
-            auto tcp_sock = co_await acceptor_->async_accept(worker->get_io_context(), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (!ec) {
-                std::shared_ptr<TcpSocket> tcp_socket = std::make_shared<TcpSocket>(tcp_handler_, std::move(tcp_sock), worker);
-                tcp_socket->set_socket_inactive_timeout_ms(socket_inactive_timeout_ms_);
-                tcp_socket->open();                            
+    boost::asio::co_spawn(
+        worker_->get_io_context(), ([port, addr, this]() -> boost::asio::awaitable<void> {
+            boost::asio::ip::tcp::endpoint endpoint;
+            endpoint.port(port);
+            if (!addr.empty()) {
+                endpoint.address(boost::asio::ip::make_address(addr));
             } else {
-                if (!running_) {
-                    co_return;
-                }
-                boost::asio::steady_timer timer(co_await this_coro::executor);
-                timer.expires_after(100ms);
-                co_await timer.async_wait(boost::asio::use_awaitable);
+                endpoint.address(boost::asio::ip::make_address("0.0.0.0"));
             }
-        }
-        co_return;
-    }), [this](std::exception_ptr exp) {
-        ((void)exp);
-        return -2;
-    });
+
+            acceptor_ = std::make_shared<boost::asio::ip::tcp::acceptor>(worker_->get_io_context(), endpoint);
+            acceptor_->set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+            while (1) {
+                boost::system::error_code ec;
+                auto worker = thread_pool_inst::get_mutable_instance().get_worker(-1);
+                auto tcp_sock = co_await acceptor_->async_accept(
+                    worker->get_io_context(), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (!ec) {
+                    std::shared_ptr<TcpSocket> tcp_socket =
+                        std::make_shared<TcpSocket>(tcp_handler_, std::move(tcp_sock), worker);
+                    tcp_socket->set_socket_inactive_timeout_ms(socket_inactive_timeout_ms_);
+                    tcp_socket->open();
+                } else {
+                    if (!running_) {
+                        co_return;
+                    }
+                    boost::asio::steady_timer timer(co_await this_coro::executor);
+                    timer.expires_after(100ms);
+                    co_await timer.async_wait(boost::asio::use_awaitable);
+                }
+            }
+            co_return;
+        }),
+        [this](std::exception_ptr exp) {
+            ((void)exp);
+            return -2;
+        });
     return 0;
 }
 
 void TcpServer::stop_listen() {
     running_ = false;
-    worker_->dispatch([this]{
+    worker_->dispatch([this] {
         if (acceptor_) {
             acceptor_->close();
             acceptor_.reset();
@@ -65,6 +68,4 @@ void TcpServer::stop_listen() {
     });
 }
 
-void TcpServer::set_socket_inactive_timeout_ms(uint32_t ms) {
-    socket_inactive_timeout_ms_ = ms;
-}
+void TcpServer::set_socket_inactive_timeout_ms(uint32_t ms) { socket_inactive_timeout_ms_ = ms; }

--- a/libs/server/tcp/tcp_server.hpp
+++ b/libs/server/tcp/tcp_server.hpp
@@ -1,14 +1,15 @@
 #pragma once
-#include <memory>
-#include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/co_spawn.hpp>
-#include <boost/asio/redirect_error.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/experimental/awaitable_operators.hpp>
 #include <boost/asio/experimental/concurrent_channel.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <memory>
 
-#include "base/thread/thread_pool.hpp"
 #include "base/network/tcp_socket.hpp"
+#include "base/thread/thread_pool.hpp"
+
 
 namespace this_coro = boost::asio::this_coro;
 using namespace boost::asio::experimental::awaitable_operators;
@@ -19,16 +20,18 @@ class TcpServer {
 public:
     TcpServer(SocketInterfaceHandler *tcp_handler, ThreadWorker *worker);
     virtual ~TcpServer();
+
 public:
-    virtual int32_t start_listen(uint16_t port, const std::string & addr = "");
+    virtual int32_t start_listen(uint16_t port, const std::string &addr = "");
     virtual void stop_listen();
     void set_socket_inactive_timeout_ms(uint32_t ms);
+
 private:
     uint16_t port_;
     uint32_t socket_inactive_timeout_ms_ = 10000;
     ThreadWorker *worker_;
     std::atomic<bool> running_{false};
-    boost::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor_;
-    SocketInterfaceHandler * tcp_handler_;
+    std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor_;
+    SocketInterfaceHandler *tcp_handler_;
 };
-};
+};  // namespace mms

--- a/libs/server/udp/udp_server.cpp
+++ b/libs/server/udp/udp_server.cpp
@@ -1,10 +1,12 @@
-#include "spdlog/spdlog.h"
-#include "base/thread/thread_pool.hpp"
-#include "base/network/udp_socket.hpp"
 #include "udp_server.hpp"
+
+#include "base/network/udp_socket.hpp"
+#include "base/thread/thread_pool.hpp"
+#include "spdlog/spdlog.h"
+
 using namespace mms;
 
-UdpServer::UdpServer(const std::vector<ThreadWorker*> & workers):workers_(workers) {
+UdpServer::UdpServer(const std::vector<ThreadWorker*>& workers) : workers_(workers) {
     udp_socks_.resize(workers.size());
     recv_bufs_.resize(workers.size());
 }
@@ -17,7 +19,7 @@ UdpServer::~UdpServer() {
     udp_socks_.clear();
 }
 
-bool UdpServer::start_listen(const std::string & ip, uint16_t port) {
+bool UdpServer::start_listen(const std::string& ip, uint16_t port) {
     if (workers_.size() <= 0) {
         return false;
     }
@@ -25,46 +27,50 @@ bool UdpServer::start_listen(const std::string & ip, uint16_t port) {
     port_ = port;
     for (size_t i = 0; i < workers_.size(); i++) {
         ThreadWorker* worker = workers_[i];
-        boost::asio::co_spawn(worker->get_io_context(),  [this, ip, port, worker, i]()->boost::asio::awaitable<bool> {
-            running_ = true;
-            boost::system::error_code ec;
-            auto sock = std::unique_ptr<boost::asio::ip::udp::socket>(new boost::asio::ip::udp::socket(worker->get_io_context()));
-            boost::asio::ip::udp::endpoint local_endpoint(boost::asio::ip::address::from_string(ip), port);
-            sock->open(boost::asio::ip::udp::v4());
-            int opt = 1;
-            setsockopt(sock->native_handle(), SOL_SOCKET, SO_REUSEADDR|SO_REUSEPORT, &opt, sizeof(opt));
-            sock->bind(local_endpoint, ec);
-            if (ec) {
-                spdlog::error("bind udp socket failed");
-            } else {
-                spdlog::info("bind udp socket succeed");
-            }
-
-            if (!sock->is_open()) {
-                spdlog::error("listen udp port:{} failed", port);
-                co_return false;
-            }
-
-            udp_socks_[i] = new UdpSocket(this, std::move(sock));
-            while(running_) {
-                boost::asio::ip::udp::endpoint remote_endpoint;
-                size_t len = co_await udp_socks_[i]->recv_from(recv_bufs_[i].data(), MAX_UDP_RECV_BUF, remote_endpoint);
-                if (!ec) {
-                    std::unique_ptr<uint8_t[]> recv_data = std::unique_ptr<uint8_t[]>(new uint8_t[len]);
-                    memcpy(recv_data.get(), recv_bufs_[i].data(), len);
-                    co_await on_udp_socket_recv(udp_socks_[i], std::move(recv_data), len, remote_endpoint);
+        boost::asio::co_spawn(
+            worker->get_io_context(),
+            [this, ip, port, worker, i]() -> boost::asio::awaitable<bool> {
+                running_ = true;
+                boost::system::error_code ec;
+                auto sock = std::unique_ptr<boost::asio::ip::udp::socket>(
+                    new boost::asio::ip::udp::socket(worker->get_io_context()));
+                boost::asio::ip::udp::endpoint local_endpoint(boost::asio::ip::make_address(ip), port);
+                sock->open(boost::asio::ip::udp::v4());
+                int opt = 1;
+                setsockopt(sock->native_handle(), SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+                sock->bind(local_endpoint, ec);
+                if (ec) {
+                    spdlog::error("bind udp socket failed");
+                } else {
+                    spdlog::info("bind udp socket succeed");
                 }
-            }
-            co_return true;
-        }, [this](std::exception_ptr exp, bool val) {
-            ((void)exp);
-            ((void)val);
-        });
+
+                if (!sock->is_open()) {
+                    spdlog::error("listen udp port:{} failed", port);
+                    co_return false;
+                }
+
+                udp_socks_[i] = new UdpSocket(this, std::move(sock));
+                while (running_) {
+                    boost::asio::ip::udp::endpoint remote_endpoint;
+                    size_t len = co_await udp_socks_[i]->recv_from(recv_bufs_[i].data(), MAX_UDP_RECV_BUF,
+                                                                   remote_endpoint);
+                    if (!ec) {
+                        std::unique_ptr<uint8_t[]> recv_data = std::unique_ptr<uint8_t[]>(new uint8_t[len]);
+                        memcpy(recv_data.get(), recv_bufs_[i].data(), len);
+                        co_await on_udp_socket_recv(udp_socks_[i], std::move(recv_data), len,
+                                                    remote_endpoint);
+                    }
+                }
+                co_return true;
+            },
+            [this](std::exception_ptr exp, bool val) {
+                ((void)exp);
+                ((void)val);
+            });
     }
 
     return true;
 }
 
-void UdpServer::stop_listen() {
-    running_ = false;
-}
+void UdpServer::stop_listen() { running_ = false; }

--- a/libs/server/xmake.lua
+++ b/libs/server/xmake.lua
@@ -1,0 +1,7 @@
+target("server", function () 
+    set_kind("static")
+    add_files("**.cpp")
+    add_includedirs(".", {public = true})
+    add_deps("base")
+    add_packages("spdlog", "openssl3")
+end)

--- a/libs/xmake.lua
+++ b/libs/xmake.lua
@@ -1,0 +1,5 @@
+includes("base")
+includes("protocol")
+includes("codec")
+includes("sdk/http")
+includes("server")

--- a/live-server/bridge/flv/flv_to_rtmp.cpp
+++ b/live-server/bridge/flv/flv_to_rtmp.cpp
@@ -1,127 +1,144 @@
-#include "spdlog/spdlog.h"
-#include <memory>
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/redirect_error.hpp>
-
 #include "flv_to_rtmp.hpp"
 
-#include "base/thread/thread_worker.hpp"
-#include "core/rtmp_media_source.hpp"
-#include "core/flv_media_sink.hpp"
-
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/rtmp/flv/flv_define.hpp"
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <memory>
 
 #include "app/publish_app.h"
+#include "base/thread/thread_worker.hpp"
 #include "config/app_config.h"
+#include "core/flv_media_sink.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "spdlog/spdlog.h"
+
 
 using namespace mms;
 
-FlvToRtmp::FlvToRtmp(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<RtmpMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+FlvToRtmp::FlvToRtmp(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                     std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                     const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<RtmpMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     rtmp_media_source_ = std::static_pointer_cast<RtmpMediaSource>(source_);
-    sink_ = std::make_shared<FlvMediaSink>(worker); 
+    sink_ = std::make_shared<FlvMediaSink>(worker);
     flv_media_sink_ = std::static_pointer_cast<FlvMediaSink>(sink_);
 }
 
-FlvToRtmp::~FlvToRtmp() {
-    CORE_DEBUG("destroy FlvToRtmp");
-}
+FlvToRtmp::~FlvToRtmp() { CORE_DEBUG("destroy FlvToRtmp"); }
 
 bool FlvToRtmp::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//10s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 10s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (rtmp_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经10秒没人播放了
-                CORE_DEBUG("close FlvToRtmp because no players for 10s");
-                break;
+                if (rtmp_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经10秒没人播放了
+                    CORE_DEBUG("close FlvToRtmp because no players for 10s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    flv_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        rtmp_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            flv_media_sink_->on_flv_tag([this](const std::vector<std::shared_ptr<FlvTag>> & flv_tags)->boost::asio::awaitable<bool> {
-                for (auto flv_tag : flv_tags) {
-                    auto tag_type = flv_tag->get_tag_type();
-                    if (tag_type == FlvTagHeader::AudioTag) {
-                        if (!this->on_audio_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::VideoTag) {
-                        if (!this->on_video_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::ScriptTag) {
-                        if (!this->on_metadata(flv_tag)) {
-                            co_return false;
+    flv_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            rtmp_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                flv_media_sink_->on_flv_tag([this](const std::vector<std::shared_ptr<FlvTag>> &flv_tags)
+                                                -> boost::asio::awaitable<bool> {
+                    for (auto flv_tag : flv_tags) {
+                        auto tag_type = flv_tag->get_tag_type();
+                        if (tag_type == FlvTagHeader::AudioTag) {
+                            if (!this->on_audio_packet(flv_tag)) {
+                                co_return false;
+                            }
+                        } else if (tag_type == FlvTagHeader::VideoTag) {
+                            if (!this->on_video_packet(flv_tag)) {
+                                co_return false;
+                            }
+                        } else if (tag_type == FlvTagHeader::ScriptTag) {
+                            if (!this->on_metadata(flv_tag)) {
+                                co_return false;
+                            }
                         }
                     }
-                }
-                
-                co_return true;
-            });
-        }
-        co_return;
-    });
+
+                    co_return true;
+                });
+            }
+            co_return;
+        });
     return true;
 }
 
 bool FlvToRtmp::on_metadata(std::shared_ptr<FlvTag> metadata_pkt) {
     auto flv_using_data = metadata_pkt->get_using_data();
-    std::shared_ptr<RtmpMessage> meta_rtmp_msg = std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    std::shared_ptr<RtmpMessage> meta_rtmp_msg =
+        std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     meta_rtmp_msg->chunk_stream_id_ = 8;
     meta_rtmp_msg->message_stream_id_ = 0;
     meta_rtmp_msg->message_type_id_ = RTMP_MESSAGE_TYPE_AMF0_DATA;
     meta_rtmp_msg->timestamp_ = metadata_pkt->tag_header.timestamp;
 
     auto unuse_data = meta_rtmp_msg->get_unuse_data();
-    memcpy((uint8_t*)unuse_data.data(), flv_using_data.data() + FLV_TAG_HEADER_BYTES, flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    memcpy((uint8_t *)unuse_data.data(), flv_using_data.data() + FLV_TAG_HEADER_BYTES,
+           flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     meta_rtmp_msg->inc_used_bytes(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     return rtmp_media_source_->on_metadata(meta_rtmp_msg);
-} 
+}
 
 bool FlvToRtmp::on_audio_packet(std::shared_ptr<FlvTag> audio_pkt) {
     auto flv_using_data = audio_pkt->get_using_data();
-    std::shared_ptr<RtmpMessage> audio_rtmp_msg = std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    std::shared_ptr<RtmpMessage> audio_rtmp_msg =
+        std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     audio_rtmp_msg->chunk_stream_id_ = 8;
     audio_rtmp_msg->message_stream_id_ = 0;
     audio_rtmp_msg->message_type_id_ = RTMP_MESSAGE_TYPE_AUDIO;
     audio_rtmp_msg->timestamp_ = audio_pkt->tag_header.timestamp;
 
     auto unuse_data = audio_rtmp_msg->get_unuse_data();
-    memcpy((uint8_t*)unuse_data.data(), flv_using_data.data() + FLV_TAG_HEADER_BYTES, flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    memcpy((uint8_t *)unuse_data.data(), flv_using_data.data() + FLV_TAG_HEADER_BYTES,
+           flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     audio_rtmp_msg->inc_used_bytes(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     return rtmp_media_source_->on_audio_packet(audio_rtmp_msg);
 }
 
 bool FlvToRtmp::on_video_packet(std::shared_ptr<FlvTag> video_pkt) {
     auto flv_using_data = video_pkt->get_using_data();
-    std::shared_ptr<RtmpMessage> video_rtmp_msg = std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    std::shared_ptr<RtmpMessage> video_rtmp_msg =
+        std::make_shared<RtmpMessage>(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     video_rtmp_msg->chunk_stream_id_ = 8;
     video_rtmp_msg->message_stream_id_ = 0;
     video_rtmp_msg->message_type_id_ = RTMP_MESSAGE_TYPE_VIDEO;
     video_rtmp_msg->timestamp_ = video_pkt->tag_header.timestamp;
 
     auto unuse_data = video_rtmp_msg->get_unuse_data();
-    memcpy((void*)unuse_data.data(), flv_using_data.data()+FLV_TAG_HEADER_BYTES, flv_using_data.size() - FLV_TAG_HEADER_BYTES);
+    memcpy((void *)unuse_data.data(), flv_using_data.data() + FLV_TAG_HEADER_BYTES,
+           flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     video_rtmp_msg->inc_used_bytes(flv_using_data.size() - FLV_TAG_HEADER_BYTES);
     return rtmp_media_source_->on_video_packet(video_rtmp_msg);
 }
@@ -132,27 +149,30 @@ void FlvToRtmp::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
-        if (rtmp_media_source_) {
-            rtmp_media_source_->close();
-            rtmp_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (flv_media_sink_) {
-            flv_media_sink_->on_flv_tag({});
-            flv_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(flv_media_sink_);
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
+            if (rtmp_media_source_) {
+                rtmp_media_source_->close();
+                rtmp_media_source_ = nullptr;
             }
-            flv_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (flv_media_sink_) {
+                flv_media_sink_->on_flv_tag({});
+                flv_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(flv_media_sink_);
+                }
+                flv_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/flv/flv_to_rtsp.cpp
+++ b/live-server/bridge/flv/flv_to_rtsp.cpp
@@ -1,102 +1,108 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/redirect_error.hpp>
-
-#include "spdlog/spdlog.h"
 #include "flv_to_rtsp.hpp"
 
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
-#include "core/rtsp_media_source.hpp"
-#include "core/flv_media_sink.hpp"
-
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/sdp/sdp.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
 #include "codec/h264/h264_codec.hpp"
 #include "codec/hevc/hevc_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
 #include "codec/mp3/mp3_codec.hpp"
-
-#include "codec/aac/adts.hpp"
-#include "base/utils/utils.h"
 #include "config/app_config.h"
-#include "app/publish_app.h"
+#include "core/flv_media_sink.hpp"
+#include "core/rtsp_media_source.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/sdp/sdp.hpp"
+#include "spdlog/spdlog.h"
+
 
 using namespace mms;
 
-FlvToRtsp::FlvToRtsp(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, 
-                     const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : 
-                     MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), 
-                     check_closable_timer_(worker->get_io_context()),
-                     wg_(worker) {
-    source_ = std::make_shared<RtspMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+FlvToRtsp::FlvToRtsp(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                     std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                     const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<RtspMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     rtsp_media_source_ = std::static_pointer_cast<RtspMediaSource>(source_);
-    sink_ = std::make_shared<FlvMediaSink>(worker); 
-    flv_media_sink_ = std::static_pointer_cast<FlvMediaSink>(sink_); 
+    sink_ = std::make_shared<FlvMediaSink>(worker);
+    flv_media_sink_ = std::static_pointer_cast<FlvMediaSink>(sink_);
     spdlog::info("create FlvToRtsp");
 }
 
-FlvToRtsp::~FlvToRtsp() {
-    spdlog::debug("destroy FlvToRtsp");
-}
+FlvToRtsp::~FlvToRtsp() { spdlog::debug("destroy FlvToRtsp"); }
 
 bool FlvToRtsp::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
-
-            if (rtsp_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                spdlog::debug("close FlvToRtsp because no players for 30s");
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
-
-    flv_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        rtsp_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            flv_media_sink_->on_flv_tag([this, self](std::vector<std::shared_ptr<FlvTag>> & flv_tags)->boost::asio::awaitable<bool> {
-                for (auto flv_tag : flv_tags) {
-                    auto tag_type = flv_tag->get_tag_type();
-                    if (tag_type == FlvTagHeader::AudioTag) {
-                        if (!co_await this->on_audio_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::VideoTag) {
-                        if (!co_await this->on_video_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::ScriptTag) {
-                        if (!co_await this->on_metadata(flv_tag)) {
-                            co_return false;
-                        }
-                    }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
                 }
-                co_return true;
-            });
-        }
-        co_return;
-    });
+
+                if (rtsp_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    spdlog::debug("close FlvToRtsp because no players for 30s");
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
+
+    flv_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            rtsp_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                flv_media_sink_->on_flv_tag(
+                    [this,
+                     self](std::vector<std::shared_ptr<FlvTag>> &flv_tags) -> boost::asio::awaitable<bool> {
+                        for (auto flv_tag : flv_tags) {
+                            auto tag_type = flv_tag->get_tag_type();
+                            if (tag_type == FlvTagHeader::AudioTag) {
+                                if (!co_await this->on_audio_packet(flv_tag)) {
+                                    co_return false;
+                                }
+                            } else if (tag_type == FlvTagHeader::VideoTag) {
+                                if (!co_await this->on_video_packet(flv_tag)) {
+                                    co_return false;
+                                }
+                            } else if (tag_type == FlvTagHeader::ScriptTag) {
+                                if (!co_await this->on_metadata(flv_tag)) {
+                                    co_return false;
+                                }
+                            }
+                        }
+                        co_return true;
+                    });
+            }
+            co_return;
+        });
     return true;
 }
-
 
 boost::asio::awaitable<bool> FlvToRtsp::on_metadata(std::shared_ptr<FlvTag> metadata_pkt) {
     metadata_ = std::make_shared<RtmpMetaDataMessage>();
@@ -121,7 +127,7 @@ boost::asio::awaitable<bool> FlvToRtsp::on_metadata(std::shared_ptr<FlvTag> meta
         auto audio_codec_id = metadata_->get_audio_codec_id();
         if (audio_codec_id == AudioTagHeader::AAC) {
             audio_codec_ = std::make_shared<AACCodec>();
-        }  else if (audio_codec_id == AudioTagHeader::MP3) {
+        } else if (audio_codec_id == AudioTagHeader::MP3) {
             audio_codec_ = std::make_shared<MP3Codec>();
         } else {
             co_return false;
@@ -129,7 +135,7 @@ boost::asio::awaitable<bool> FlvToRtsp::on_metadata(std::shared_ptr<FlvTag> meta
     }
 
     co_return true;
-} 
+}
 
 boost::asio::awaitable<bool> FlvToRtsp::on_video_packet(std::shared_ptr<FlvTag> video_pkt) {
     spdlog::info("on_video_packet hevc");
@@ -137,10 +143,11 @@ boost::asio::awaitable<bool> FlvToRtsp::on_video_packet(std::shared_ptr<FlvTag> 
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
     if (!video_codec_) {
         VideoTagHeader header;
-        header.decode((uint8_t*)payload.data(), payload.size());
+        header.decode((uint8_t *)payload.data(), payload.size());
         if (header.get_codec_id() == VideoTagHeader::AVC) {
             video_codec_ = std::make_shared<H264Codec>();
-        } else if (header.get_codec_id() == VideoTagHeader::HEVC || header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
+        } else if (header.get_codec_id() == VideoTagHeader::HEVC ||
+                   header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
             video_codec_ = std::make_shared<HevcCodec>();
         } else {
             co_return false;
@@ -152,7 +159,7 @@ boost::asio::awaitable<bool> FlvToRtsp::on_video_packet(std::shared_ptr<FlvTag> 
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         co_return co_await process_h265_packet(video_pkt);
     }
-    
+
     co_return true;
 }
 
@@ -163,7 +170,7 @@ boost::asio::awaitable<bool> FlvToRtsp::on_audio_packet(std::shared_ptr<FlvTag> 
 
     if (audio_codec_->get_codec_type() == CODEC_AAC) {
         co_return co_await process_aac_packet(audio_pkt);
-    } 
+    }
     co_return true;
 }
 
@@ -171,23 +178,25 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h264_packet(std::shared_ptr<FlvT
     VideoTagHeader header;
     std::string_view payload = video_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
 
-    H264Codec *h264_codec = ((H264Codec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    H264Codec *h264_codec = ((H264Codec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析avc configuration heade
         AVCDecoderConfigurationRecord avc_decoder_configuration_record;
-        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t *)payload.data() + header_consumed,
+                                                                  payload.size() - header_consumed);
         if (consumed < 0) {
             co_return false;
         }
 
-        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(), avc_decoder_configuration_record.get_pps());
+        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(),
+                                avc_decoder_configuration_record.get_pps());
         nalu_length_size_ = avc_decoder_configuration_record.nalu_length_size_minus_one + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
             co_return false;
@@ -198,15 +207,15 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h264_packet(std::shared_ptr<FlvT
         }
 
         co_return true;
-    } 
+    }
 
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         co_return false;
     }
-
 
     // 判断sps,pps,aud等
     bool has_aud_nalu = false;
@@ -215,7 +224,7 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h264_packet(std::shared_ptr<FlvT
     if (!video_codec_) {
         co_return false;
     }
-    
+
     VIDEODATA *video_data = (VIDEODATA *)video_pkt->tag_data.get();
     if (first_video_pts_ == 0) {
         first_video_pts_ = video_pkt->tag_header.timestamp + video_data->header.composition_time;
@@ -233,21 +242,25 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h264_packet(std::shared_ptr<FlvT
             h264_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type == H264NaluTypeIDR) {
             if (!has_pps_nalu && !has_sps_nalu) {
-                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(), h264_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(), h264_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(),
+                                                       h264_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(),
+                                                       h264_codec->get_sps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
             }
         }
     }
 
-    static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
-    static std::string_view aud_nalu((char*)default_aud_nalu, 2);
+    static uint8_t default_aud_nalu[] = {0x09, 0xf0};
+    static std::string_view aud_nalu((char *)default_aud_nalu, 2);
     if (!has_aud_nalu) {
         nalus.push_front(aud_nalu);
     }
 
-    auto rtp_pkts = video_rtp_packer_.pack(nalus, video_pt_, 0, (video_pkt->tag_header.timestamp + video_data->header.composition_time - first_video_pts_)*90);
+    auto rtp_pkts = video_rtp_packer_.pack(
+        nalus, video_pt_, 0,
+        (video_pkt->tag_header.timestamp + video_data->header.composition_time - first_video_pts_) * 90);
     co_await rtsp_media_source_->on_video_packets(rtp_pkts);
     co_return true;
 }
@@ -256,24 +269,25 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h265_packet(std::shared_ptr<FlvT
     VideoTagHeader header;
     std::string_view payload = video_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
 
-    HevcCodec *hevc_codec = ((HevcCodec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    HevcCodec *hevc_codec = ((HevcCodec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析hevc configuration heade
         HEVCDecoderConfigurationRecord hevc_decoder_configuration_record;
-        int32_t consumed = hevc_decoder_configuration_record.decode((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = hevc_decoder_configuration_record.decode(
+            (uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed);
         if (consumed < 0) {
             co_return false;
         }
 
-        hevc_codec->set_sps_pps_vps(hevc_decoder_configuration_record.get_sps(), 
-                                    hevc_decoder_configuration_record.get_pps(), 
+        hevc_codec->set_sps_pps_vps(hevc_decoder_configuration_record.get_sps(),
+                                    hevc_decoder_configuration_record.get_pps(),
                                     hevc_decoder_configuration_record.get_vps());
         nalu_length_size_ = hevc_decoder_configuration_record.lengthSizeMinusOne + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
@@ -285,11 +299,12 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h265_packet(std::shared_ptr<FlvT
         }
 
         co_return true;
-    } 
+    }
 
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         co_return false;
     }
@@ -302,7 +317,7 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h265_packet(std::shared_ptr<FlvT
     if (!video_codec_) {
         co_return false;
     }
-    
+
     VIDEODATA *video_data = (VIDEODATA *)video_pkt->tag_data.get();
     if (first_video_pts_ == 0) {
         first_video_pts_ = video_pkt->tag_header.timestamp + video_data->header.composition_time;
@@ -326,15 +341,18 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h265_packet(std::shared_ptr<FlvT
 
     if (has_key_nalu) {
         if (!has_pps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(), hevc_codec->get_pps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(),
+                                                         hevc_codec->get_pps_nalu().size()));
         }
 
         if (!has_sps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
 
         if (!has_vps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
     }
 
@@ -344,12 +362,14 @@ boost::asio::awaitable<bool> FlvToRtsp::process_h265_packet(std::shared_ptr<FlvT
     //     nalus.push_front(aud_nalu);
     // }
 
-    auto rtp_pkts = video_rtp_packer_.pack(nalus, video_pt_, 0, (video_pkt->tag_header.timestamp + video_data->header.composition_time - first_video_pts_)*90);
+    auto rtp_pkts = video_rtp_packer_.pack(
+        nalus, video_pt_, 0,
+        (video_pkt->tag_header.timestamp + video_data->header.composition_time - first_video_pts_) * 90);
     co_await rtsp_media_source_->on_video_packets(rtp_pkts);
     co_return true;
 }
 
-int32_t FlvToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> & nalus) {
+int32_t FlvToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> &nalus) {
     uint8_t *data_start = data;
     while (len > 0) {
         int32_t nalu_len = 0;
@@ -372,7 +392,7 @@ int32_t FlvToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_v
             return -2;
         }
 
-        nalus.emplace_back(std::string_view((char*)data, nalu_len));
+        nalus.emplace_back(std::string_view((char *)data, nalu_len));
         data += nalu_len;
         len -= nalu_len;
     }
@@ -383,18 +403,19 @@ boost::asio::awaitable<bool> FlvToRtsp::process_aac_packet(std::shared_ptr<FlvTa
     AudioTagHeader header;
     std::string_view payload = audio_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
-    
-    AACCodec *aac_codec = ((AACCodec*)audio_codec_.get());    
-    if (header.is_seq_header()) {// 关键帧索引
+
+    AACCodec *aac_codec = ((AACCodec *)audio_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         audio_ready_ = true;
         audio_header_ = audio_pkt;
         // 解析avc configuration heade
         auto audio_config = std::make_shared<AudioSpecificConfig>();
-        int32_t consumed = audio_config->parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = audio_config->parse((uint8_t *)payload.data() + header_consumed,
+                                               payload.size() - header_consumed);
         if (consumed < 0) {
             spdlog::error("parse aac audio header failed, ret:{}", consumed);
             co_return false;
@@ -417,11 +438,11 @@ boost::asio::awaitable<bool> FlvToRtsp::process_aac_packet(std::shared_ptr<FlvTa
     }
 
     int32_t payload_size = payload.size() - header_consumed;
-    int16_t au_header_bytes = (13 + 3)/8;
-    char *p = (char*)audio_buf_;
-    *(uint16_t*)p = htons(au_header_bytes*8);
+    int16_t au_header_bytes = (13 + 3) / 8;
+    char *p = (char *)audio_buf_;
+    *(uint16_t *)p = htons(au_header_bytes * 8);
     p += 2;
-    memset(p, 0, 2);   
+    memset(p, 0, 2);
     BitStream bit_stream(std::string_view(p, au_header_bytes));
     int16_t au_size = payload_size;
     bit_stream.write_bits(13, au_size);
@@ -432,7 +453,9 @@ boost::asio::awaitable<bool> FlvToRtsp::process_aac_packet(std::shared_ptr<FlvTa
     memcpy(p, payload.data() + header_consumed, payload_size);
     p += payload_size;
 
-    auto rtp_pkts = audio_rtp_packer_.pack((char*)audio_buf_, p - (char*)audio_buf_, audio_pt_, 0, audio_pkt->tag_header.timestamp*audio_config->sampling_frequency/1000);
+    auto rtp_pkts =
+        audio_rtp_packer_.pack((char *)audio_buf_, p - (char *)audio_buf_, audio_pt_, 0,
+                               audio_pkt->tag_header.timestamp * audio_config->sampling_frequency / 1000);
     auto ret = co_await rtsp_media_source_->on_audio_packets(rtp_pkts);
     if (!ret) {
         co_return false;
@@ -449,11 +472,8 @@ a=tool:libavformat 59.34.102
 m=video 0 RTP/AVP 96
 b=AS:1890
 a=rtpmap:96 H264/90000
-a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs; profile-level-id=64001E
-a=control:streamid=0
-m=audio 0 RTP/AVP 97
-b=AS:128
-a=rtpmap:97 MPEG4-GENERIC/48000/2
+a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs;
+profile-level-id=64001E a=control:streamid=0 m=audio 0 RTP/AVP 97 b=AS:128 a=rtpmap:97 MPEG4-GENERIC/48000/2
 a=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=119056E500
 a=control:streamid=1
 */
@@ -464,11 +484,9 @@ t=0 0
 a=tool:mms
 m=video 0 RTP/AVP 96
 a=rtpmap:96 H264/90000
-a=fmtp:96 profile-level-id=64001E; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs; packetization-mode=1
-a=control:streamid=0
-m=audio 0 RTP/AVP 97
-a=rtpmap:97 MPEG4-GENERIC/44100/2
-a=fmtp:97 config=121056E500; indexdeltalength=3; indexlength=3; sizelength=13; mode=AAC-hbr; profile-level-id=1
+a=fmtp:96 profile-level-id=64001E; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs;
+packetization-mode=1 a=control:streamid=0 m=audio 0 RTP/AVP 97 a=rtpmap:97 MPEG4-GENERIC/44100/2 a=fmtp:97
+config=121056E500; indexdeltalength=3; indexlength=3; sizelength=13; mode=AAC-hbr; profile-level-id=1
 a=control:streamid=1
 */
 
@@ -483,8 +501,8 @@ a=fmtp:97 config=1210; indexdeltalength=3; indexlength=3; sizelength=13; mode=AA
 a=control:streamid=0
 m=video 0 RTP/AVP/TCP 96
 a=rtpmap:96 H264/90000
-a=fmtp:96 sprop-parameter-sets=Z0LAHtoCgL/lwFqAgICgAAADACAAAAZR4sXU,aM48gA==; profile-level-id=42001f; level-asymmetry-allowed=1; packetization-mode=1
-a=control:streamid=1
+a=fmtp:96 sprop-parameter-sets=Z0LAHtoCgL/lwFqAgICgAAADACAAAAZR4sXU,aM48gA==; profile-level-id=42001f;
+level-asymmetry-allowed=1; packetization-mode=1 a=control:streamid=1
 */
 bool FlvToRtsp::generate_sdp() {
     if (has_audio_ && !audio_codec_->is_ready()) {
@@ -499,10 +517,10 @@ bool FlvToRtsp::generate_sdp() {
 
     sdp_ = std::make_shared<Sdp>();
     sdp_->set_version(0);
-    sdp_->set_origin({"-", 0, 0, "IN", "IP4", "127.0.0.1"}); // o=- get_rand64 1 IN IP4 127.0.0.1
+    sdp_->set_origin({"-", 0, 0, "IN", "IP4", "127.0.0.1"});  // o=- get_rand64 1 IN IP4 127.0.0.1
     auto session_name = domain_name_ + "/" + app_name_ + "/" + stream_name_;
-    sdp_->set_session_name(session_name);                                  //
-    sdp_->set_time({0, 0});                                                // t=0 0
+    sdp_->set_session_name(session_name);  //
+    sdp_->set_time({0, 0});                // t=0 0
     sdp_->set_tool({"mms"});
     if (has_audio_) {
         MediaSdp audio_sdp;
@@ -513,24 +531,29 @@ bool FlvToRtsp::generate_sdp() {
         audio_sdp.add_fmt(audio_pt_);
         audio_sdp.set_control(Control("streamid=1"));
         if (audio_codec_->get_codec_type() == CODEC_AAC) {
-            auto aac_codec = (AACCodec*)audio_codec_.get();
+            auto aac_codec = (AACCodec *)audio_codec_.get();
             auto audio_specific_config = aac_codec->get_audio_specific_config();
             if (!audio_specific_config) {
                 return false;
             }
-            Payload audio_payload(audio_pt_, "MPEG4-GENERIC", audio_specific_config->sampling_frequency, {std::to_string(audio_specific_config->channel_configuration)});
+            Payload audio_payload(audio_pt_, "MPEG4-GENERIC", audio_specific_config->sampling_frequency,
+                                  {std::to_string(audio_specific_config->channel_configuration)});
             Fmtp fmtp;
             /*
             struct AUConfig {
-                uint32_t constant_size;//constant_size和size_length不能同时出现, 一般都是size_length，目前先处理这种情况，constant_size应该是在某种编码模式固定长度的时候用
-                uint16_t size_length = 0;//The number of bits on which the AU-size field is encoded in the AU-header. 如果没有这个字段，则au-headers-length字段也不存在
-                uint16_t index_length = 0;//The number of bits on which the AU-Index is encoded in the first AU-header
-                uint16_t index_delta_length = 0;//The number of bits on which the AU-Index-delta field is encoded in any non-first AU-header.
-                uint16_t cts_delta_length;//The number of bits on which the CTS-delta field is encoded in the AU-header.
-                uint16_t dts_delta_length;//The number of bits on which the DTS-delta field is encoded in the AU-header.
-                uint8_t random_access_indication;//A decimal value of zero or one, indicating whether the RAP-flag is present in the AU-header.
-                uint8_t stream_state_indication;//The number of bits on which the Stream-state field is encoded in the AU-header.
-                uint16_t auxiliary_data_size_length;//The number of bits that is used to encode the auxiliary-data-size field.
+                uint32_t constant_size;//constant_size和size_length不能同时出现,
+            一般都是size_length，目前先处理这种情况，constant_size应该是在某种编码模式固定长度的时候用
+                uint16_t size_length = 0;//The number of bits on which the AU-size field is encoded in the
+            AU-header. 如果没有这个字段，则au-headers-length字段也不存在 uint16_t index_length = 0;//The
+            number of bits on which the AU-Index is encoded in the first AU-header uint16_t index_delta_length
+            = 0;//The number of bits on which the AU-Index-delta field is encoded in any non-first AU-header.
+                uint16_t cts_delta_length;//The number of bits on which the CTS-delta field is encoded in the
+            AU-header. uint16_t dts_delta_length;//The number of bits on which the DTS-delta field is encoded
+            in the AU-header. uint8_t random_access_indication;//A decimal value of zero or one, indicating
+            whether the RAP-flag is present in the AU-header. uint8_t stream_state_indication;//The number of
+            bits on which the Stream-state field is encoded in the AU-header. uint16_t
+            auxiliary_data_size_length;//The number of bits that is used to encode the auxiliary-data-size
+            field.
             };
             */
             fmtp.set_pt(audio_pt_);
@@ -542,7 +565,7 @@ bool FlvToRtsp::generate_sdp() {
             auto config_size = audio_specific_config->size();
             std::string config;
             config.resize(config_size);
-            audio_specific_config->encode((uint8_t*)config.data(), config_size);
+            audio_specific_config->encode((uint8_t *)config.data(), config_size);
             std::string hex_config;
             Utils::bin_to_hex_str(config, hex_config);
             fmtp.add_param("config", hex_config);
@@ -561,7 +584,7 @@ bool FlvToRtsp::generate_sdp() {
         video_sdp.set_proto("RTP/AVP");
         video_sdp.set_control(Control("streamid=0"));
         if (video_codec_->get_codec_type() == CODEC_H264) {
-            auto h264_codec = (H264Codec*)video_codec_.get();
+            auto h264_codec = (H264Codec *)video_codec_.get();
             auto sps = h264_codec->get_sps_nalu();
             auto pps = h264_codec->get_pps_nalu();
             std::string sps_base64;
@@ -575,13 +598,13 @@ bool FlvToRtsp::generate_sdp() {
             fmtp.add_param("packetization-mode", "1");
             fmtp.add_param("level-asymmetry-allowed", "1");
             fmtp.add_param("profile-level-id", "42001f");
-            fmtp.add_param("sprop-parameter-sets", sps_base64 + ","+pps_base64);
+            fmtp.add_param("sprop-parameter-sets", sps_base64 + "," + pps_base64);
             video_payload.add_fmtp(fmtp);
 
             video_sdp.add_payload(video_payload);
             sdp_->add_media_sdp(video_sdp);
         } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
-            auto h265_codec = (HevcCodec*)video_codec_.get();
+            auto h265_codec = (HevcCodec *)video_codec_.get();
             auto sps = h265_codec->get_sps_nalu();
             auto pps = h265_codec->get_pps_nalu();
             auto vps = h265_codec->get_vps_nalu();
@@ -620,29 +643,32 @@ void FlvToRtsp::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (rtsp_media_source_) {
-            rtsp_media_source_->close();
-            rtsp_media_source_ = nullptr;
-        }
+            if (rtsp_media_source_) {
+                rtsp_media_source_->close();
+                rtsp_media_source_ = nullptr;
+            }
 
-        auto origin_source = origin_source_.lock();
-        if (flv_media_sink_) {
-            flv_media_sink_->on_flv_tag({});
-            flv_media_sink_->close();
+            auto origin_source = origin_source_.lock();
+            if (flv_media_sink_) {
+                flv_media_sink_->on_flv_tag({});
+                flv_media_sink_->close();
+
+                if (origin_source) {
+                    origin_source->remove_media_sink(flv_media_sink_);
+                }
+                flv_media_sink_ = nullptr;
+            }
 
             if (origin_source) {
-                origin_source->remove_media_sink(flv_media_sink_);
+                origin_source->remove_bridge(shared_from_this());
             }
-            flv_media_sink_ = nullptr;
-        }
-
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/flv/flv_to_ts.cpp
+++ b/live-server/bridge/flv/flv_to_ts.cpp
@@ -3,107 +3,113 @@
  * @Date: 2023-11-09 20:49:39
  * @LastEditTime: 2023-12-27 21:57:32
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\flv_to_ts.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "flv_to_ts.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "spdlog/spdlog.h"
-#include "flv_to_ts.hpp"
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/ts/ts_pat_pmt.hpp"
-#include "protocol/ts/ts_header.hpp"
-#include "protocol/ts/ts_segment.hpp"
-
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-
+#include "app/publish_app.h"
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
+#include "codec/av1/av1_codec.hpp"
 #include "codec/h264/h264_codec.hpp"
 #include "codec/hevc/hevc_codec.hpp"
-#include "codec/av1/av1_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
 #include "codec/mp3/mp3_codec.hpp"
-#include "codec/aac/adts.hpp"
-
-#include "base/utils/utils.h"
-#include "app/publish_app.h"
-#include "core/flv_media_sink.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
 #include "config/app_config.h"
+#include "core/flv_media_sink.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/ts/ts_header.hpp"
+#include "protocol/ts/ts_pat_pmt.hpp"
+#include "protocol/ts/ts_segment.hpp"
+#include "spdlog/spdlog.h"
+
 
 using namespace mms;
-FlvToTs::FlvToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, 
-                 const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : 
-                 MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), 
-                 check_closable_timer_(worker->get_io_context()),
-                 wg_(worker) {
+FlvToTs::FlvToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                 std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                 const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
     sink_ = std::make_shared<FlvMediaSink>(worker);
     flv_media_sink_ = std::static_pointer_cast<FlvMediaSink>(sink_);
-    source_ = std::make_shared<TsMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<TsMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     ts_media_source_ = std::static_pointer_cast<TsMediaSource>(source_);
     video_pes_segs_.reserve(1024);
     spdlog::info("create flv to ts");
 }
 
-FlvToTs::~FlvToTs() {
-
-}
+FlvToTs::~FlvToTs() {}
 
 bool FlvToTs::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (ts_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                spdlog::debug("close FlvToTs because no players for 30s");
-                break;
+                if (ts_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    spdlog::debug("close FlvToTs because no players for 30s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    flv_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        ts_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            flv_media_sink_->on_flv_tag([this](const std::vector<std::shared_ptr<FlvTag>> & flv_tags)->boost::asio::awaitable<bool> {
-                for (auto flv_tag : flv_tags) {
-                    auto tag_type = flv_tag->get_tag_type();
-                    if (tag_type == FlvTagHeader::AudioTag) {
-                        if (!this->on_audio_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::VideoTag) {
-                        if (!this->on_video_packet(flv_tag)) {
-                            co_return false;
-                        }
-                    } else if (tag_type == FlvTagHeader::ScriptTag) {
-                        if (!this->on_metadata(flv_tag)) {
-                            co_return false;
+    flv_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            ts_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                flv_media_sink_->on_flv_tag([this](const std::vector<std::shared_ptr<FlvTag>> &flv_tags)
+                                                -> boost::asio::awaitable<bool> {
+                    for (auto flv_tag : flv_tags) {
+                        auto tag_type = flv_tag->get_tag_type();
+                        if (tag_type == FlvTagHeader::AudioTag) {
+                            if (!this->on_audio_packet(flv_tag)) {
+                                co_return false;
+                            }
+                        } else if (tag_type == FlvTagHeader::VideoTag) {
+                            if (!this->on_video_packet(flv_tag)) {
+                                co_return false;
+                            }
+                        } else if (tag_type == FlvTagHeader::ScriptTag) {
+                            if (!this->on_metadata(flv_tag)) {
+                                co_return false;
+                            }
                         }
                     }
-                }
-                co_return true;
-            });
-        }
-        co_return;
-    });
+                    co_return true;
+                });
+            }
+            co_return;
+        });
     return true;
 }
 
@@ -151,7 +157,7 @@ bool FlvToTs::on_metadata(std::shared_ptr<FlvTag> metadata_pkt) {
     }
 
     if (has_video_) {
-        PCR_PID = video_pid_; 
+        PCR_PID = video_pid_;
     } else if (has_audio_) {
         PCR_PID = audio_pid_;
     }
@@ -163,13 +169,14 @@ bool FlvToTs::on_video_packet(std::shared_ptr<FlvTag> video_pkt) {
     if (!video_codec_) {
         VideoTagHeader header;
         auto payload = video_pkt->get_using_data();
-        header.decode((uint8_t*)payload.data(), payload.size());
+        header.decode((uint8_t *)payload.data(), payload.size());
         if (header.get_codec_id() == VideoTagHeader::AVC) {
             video_codec_ = std::make_shared<H264Codec>();
             video_pid_ = TS_VIDEO_AVC_PID;
             video_type_ = TsStreamVideoH264;
             continuity_counter_[video_pid_] = 0;
-        } else if (header.get_codec_id() == VideoTagHeader::HEVC || header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
+        } else if (header.get_codec_id() == VideoTagHeader::HEVC ||
+                   header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
             video_codec_ = std::make_shared<HevcCodec>();
             video_pid_ = TS_VIDEO_HEVC_PID;
             video_type_ = TsStreamVideoH265;
@@ -184,7 +191,7 @@ bool FlvToTs::on_video_packet(std::shared_ptr<FlvTag> video_pkt) {
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         return process_h265_packet(video_pkt);
     }
-    
+
     return false;
 }
 
@@ -192,48 +199,46 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
 
-    H264Codec *h264_codec = ((H264Codec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    H264Codec *h264_codec = ((H264Codec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析avc configuration heade
         AVCDecoderConfigurationRecord avc_decoder_configuration_record;
-        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t *)payload.data() + header_consumed,
+                                                                  payload.size() - header_consumed);
         if (consumed < 0) {
             return false;
         }
 
-        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(), avc_decoder_configuration_record.get_pps());
+        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(),
+                                avc_decoder_configuration_record.get_pps());
         nalu_length_size_ = avc_decoder_configuration_record.nalu_length_size_minus_one + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
             return false;
         }
         return true;
-    } 
+    }
 
     bool is_key = header.is_key_frame() && !header.is_seq_header();
-    if (!curr_seg_ && !is_key) {//片段开始的帧，必须是关键帧
+    if (!curr_seg_ && !is_key) {  // 片段开始的帧，必须是关键帧
         return false;
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     if (curr_seg_) {
         if (publish_app_->can_reap_ts(is_key, curr_seg_)) {
-            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by video", 
-                            get_session_name(), 
-                            curr_seg_->get_seqno(),
-                            curr_seg_->get_filename(),
-                            curr_seg_->get_ts_bytes()/1024,
-                            curr_seg_->get_duration()
-            );
+            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by video", get_session_name(),
+                     curr_seg_->get_seqno(), curr_seg_->get_filename(), curr_seg_->get_ts_bytes() / 1024,
+                     curr_seg_->get_duration());
             curr_seg_->set_reaped();
             on_ts_segment(curr_seg_);
             curr_seg_ = nullptr;
@@ -249,7 +254,8 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     }
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         return false;
     }
@@ -274,22 +280,24 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
             h264_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type == H264NaluTypeIDR) {
             if (!has_pps_nalu && !has_sps_nalu) {
-                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(), h264_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(), h264_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(),
+                                                       h264_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(),
+                                                       h264_codec->get_sps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
             }
         }
     }
 
-    static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
-    static std::string_view aud_nalu((char*)default_aud_nalu, 2);
+    static uint8_t default_aud_nalu[] = {0x09, 0xf0};
+    static std::string_view aud_nalu((char *)default_aud_nalu, 2);
     if (!has_aud_nalu) {
         nalus.push_front(aud_nalu);
     }
     // 计算payload长度(第一个nalu头部4个字节，后面的头部只需要3字节)
-    int32_t payload_size = nalus.size()*3 + 1;//头部的总字节数
-    for (auto & nalu : nalus) {
+    int32_t payload_size = nalus.size() * 3 + 1;  // 头部的总字节数
+    for (auto &nalu : nalus) {
         payload_size += nalu.size();
     }
 
@@ -298,47 +306,47 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     pes_header.stream_id = TsPESStreamIdVideoCommon;
 
     char *pes = video_pes_header_;
-    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};//固定3字节头,跟annexb没什么关系
+    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};  // 固定3字节头,跟annexb没什么关系
     memcpy(pes, pes_start_prefix, 3);
     pes += 3;
     // stream_id
     *pes++ = TsPESStreamIdVideoCommon;
     // PES_packet_length
     uint8_t PTS_DTS_flags = 0x03;
-    if (header.composition_time == 0) {//dts = pts时，只需要dts
+    if (header.composition_time == 0) {  // dts = pts时，只需要dts
         PTS_DTS_flags = 0x02;
     }
 
-    //PES_header_data_length
+    // PES_header_data_length
     uint8_t PES_header_data_length = 0;
     if (PTS_DTS_flags == 0x02) {
-        PES_header_data_length = 5;//DTS 5字节
-        pes_header.dts = pes_header.pts = video_pkt->tag_header.timestamp*90;
+        PES_header_data_length = 5;  // DTS 5字节
+        pes_header.dts = pes_header.pts = video_pkt->tag_header.timestamp * 90;
     } else if (PTS_DTS_flags == 0x03) {
-        PES_header_data_length = 10;//PTS 5字节
-        pes_header.dts = video_pkt->tag_header.timestamp*90;
-        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time)*90;
+        PES_header_data_length = 10;  // PTS 5字节
+        pes_header.dts = video_pkt->tag_header.timestamp * 90;
+        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time) * 90;
     }
 
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes_header.PES_packet_length = PES_packet_length;
 
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
 
@@ -346,17 +354,17 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     pes_header.PES_header_data_length = PES_header_data_length;
 
     if (PTS_DTS_flags & 0x02) {
-        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time)*90;
+        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time) * 90;
     }
 
     if (PTS_DTS_flags & 0x01) {
-        pes_header.dts = video_pkt->tag_header.timestamp*90;
+        pes_header.dts = video_pkt->tag_header.timestamp * 90;
     }
 
     *pes++ = PES_header_data_length;
     VIDEODATA *video_data = (VIDEODATA *)video_pkt->tag_data.get();
-    if (PTS_DTS_flags & 0x02) {// 填充pts
-        uint64_t pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time)*90;
+    if (PTS_DTS_flags & 0x02) {  // 填充pts
+        uint64_t pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time) * 90;
         int32_t val = 0;
         val = int32_t(0x02 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -365,13 +373,13 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((pts)&0x7fff) << 1) | 1);
+        val = int32_t((((pts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
 
-    if (PTS_DTS_flags & 0x01) {// 填充dts
-        uint64_t dts = video_pkt->tag_header.timestamp*90;
+    if (PTS_DTS_flags & 0x01) {  // 填充dts
+        uint64_t dts = video_pkt->tag_header.timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -380,7 +388,7 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((dts)&0x7fff) << 1) | 1);
+        val = int32_t((((dts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
@@ -390,10 +398,10 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     video_pes_segs_.clear();
     video_pes_segs_.emplace_back(std::string_view(video_pes_header_, video_pes_len));
 
-    static char annexb_start_code1[] = { 0x00, 0x00, 0x01 };
-    static char annexb_start_code2[] = { 0x00, 0x00, 0x00, 0x01 };    
+    static char annexb_start_code1[] = {0x00, 0x00, 0x01};
+    static char annexb_start_code2[] = {0x00, 0x00, 0x00, 0x01};
     bool first_nalu = true;
-    for (auto & nalu : nalus) {
+    for (auto &nalu : nalus) {
         if (first_nalu) {
             first_nalu = false;
             video_pes_segs_.emplace_back(std::string_view(annexb_start_code2, 4));
@@ -406,11 +414,11 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
         video_pes_segs_.emplace_back(nalu);
         video_pes_len += nalu.size();
     }
-    
+
     pes_packet->alloc_buf(video_pes_len);
-    for (auto & seg : video_pes_segs_) {
+    for (auto &seg : video_pes_segs_) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
     pes_packet->is_key = is_key;
@@ -422,12 +430,11 @@ bool FlvToTs::process_h264_packet(std::shared_ptr<FlvTag> video_pkt) {
     return true;
 }
 
-
 bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
@@ -435,14 +442,15 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     if (!video_codec_) {
         return false;
     }
-    
-    HevcCodec *hevc_codec = ((HevcCodec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+
+    HevcCodec *hevc_codec = ((HevcCodec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析hvcc configuration heade
         HEVCDecoderConfigurationRecord hevc_decoder_configuration_record;
-        int32_t consumed = hevc_decoder_configuration_record.decode((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = hevc_decoder_configuration_record.decode(
+            (uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed);
         if (consumed == 0) {
             return false;
         }
@@ -453,26 +461,22 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
             return false;
         }
         return true;
-    } 
+    }
 
     bool is_key = header.is_key_frame() && !header.is_seq_header();
-    if (!curr_seg_ && !is_key) {//片段开始的帧，必须是关键帧
+    if (!curr_seg_ && !is_key) {  // 片段开始的帧，必须是关键帧
         return false;
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     if (curr_seg_) {
         if (publish_app_->can_reap_ts(is_key, curr_seg_)) {
-            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by video", 
-                            get_session_name(), 
-                            curr_seg_->get_seqno(),
-                            curr_seg_->get_filename(),
-                            curr_seg_->get_ts_bytes()/1024,
-                            curr_seg_->get_duration()
-            );
+            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by video", get_session_name(),
+                     curr_seg_->get_seqno(), curr_seg_->get_filename(), curr_seg_->get_ts_bytes() / 1024,
+                     curr_seg_->get_duration());
             curr_seg_->set_reaped();
             on_ts_segment(curr_seg_);
             curr_seg_ = nullptr;
@@ -488,7 +492,8 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     }
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         return false;
     }
@@ -514,24 +519,27 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
             has_key_nalu = true;
         }
     }
-    
+
     if (has_key_nalu) {
         if (!has_pps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(), hevc_codec->get_pps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(),
+                                                         hevc_codec->get_pps_nalu().size()));
         }
 
         if (!has_sps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
 
         if (!has_vps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
     }
 
     // 计算payload长度(第一个nalu头部4个字节，后面的头部只需要3字节)
-    int32_t payload_size = nalus.size()*3 + 1;//头部的总字节数
-    for (auto & nalu : nalus) {
+    int32_t payload_size = nalus.size() * 3 + 1;  // 头部的总字节数
+    for (auto &nalu : nalus) {
         payload_size += nalu.size();
     }
 
@@ -539,7 +547,7 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     // uint8_t *pes = video_pes_.get();
     pes_header.stream_id = TsPESStreamIdVideoCommon;
     char *pes = video_pes_header_;
-    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};//固定3字节头,跟annexb没什么关系
+    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};  // 固定3字节头,跟annexb没什么关系
     memcpy(pes, pes_start_prefix, 3);
     pes += 3;
     // stream_id
@@ -547,39 +555,39 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     // PES_packet_length
     VIDEODATA *video_data = (VIDEODATA *)video_pkt->tag_data.get();
     uint8_t PTS_DTS_flags = 0x03;
-    if (video_data->header.composition_time == 0) {//dts = pts时，只需要dts
+    if (video_data->header.composition_time == 0) {  // dts = pts时，只需要dts
         PTS_DTS_flags = 0x02;
     }
 
-    //PES_header_data_length
+    // PES_header_data_length
     uint8_t PES_header_data_length = 0;
-    
+
     if (PTS_DTS_flags == 0x02) {
-        PES_header_data_length = 5;//DTS 5字节
-        pes_header.dts = pes_header.pts = video_pkt->tag_header.timestamp*90;
+        PES_header_data_length = 5;  // DTS 5字节
+        pes_header.dts = pes_header.pts = video_pkt->tag_header.timestamp * 90;
     } else if (PTS_DTS_flags == 0x03) {
-        PES_header_data_length = 10;//PTS 5字节
-        pes_header.dts = video_pkt->tag_header.timestamp*90;
-        pes_header.pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time)*90;
+        PES_header_data_length = 10;  // PTS 5字节
+        pes_header.dts = video_pkt->tag_header.timestamp * 90;
+        pes_header.pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time) * 90;
     }
 
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
 
@@ -587,16 +595,16 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     pes_header.PES_header_data_length = PES_header_data_length;
 
     if (PTS_DTS_flags & 0x02) {
-        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time)*90;
+        pes_header.pts = (video_pkt->tag_header.timestamp + header.composition_time) * 90;
     }
 
     if (PTS_DTS_flags & 0x01) {
-        pes_header.dts = video_pkt->tag_header.timestamp*90;
+        pes_header.dts = video_pkt->tag_header.timestamp * 90;
     }
 
     *pes++ = PES_header_data_length;
-    if (PTS_DTS_flags & 0x02) {// 填充pts
-        uint64_t pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time)*90;
+    if (PTS_DTS_flags & 0x02) {  // 填充pts
+        uint64_t pts = (video_pkt->tag_header.timestamp + video_data->header.composition_time) * 90;
         int32_t val = 0;
         val = int32_t(0x02 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -605,13 +613,13 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((pts)&0x7fff) << 1) | 1);
+        val = int32_t((((pts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
 
-    if (PTS_DTS_flags & 0x01) {// 填充dts
-        uint64_t dts = video_pkt->tag_header.timestamp*90;
+    if (PTS_DTS_flags & 0x01) {  // 填充dts
+        uint64_t dts = video_pkt->tag_header.timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -620,7 +628,7 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((dts)&0x7fff) << 1) | 1);
+        val = int32_t((((dts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
@@ -629,10 +637,10 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     video_pes_segs_.clear();
     video_pes_segs_.emplace_back(std::string_view(video_pes_header_, video_pes_len));
 
-    static char annexb_start_code1[] = { 0x00, 0x00, 0x01 };
-    static char annexb_start_code2[] = { 0x00, 0x00, 0x00, 0x01 };    
+    static char annexb_start_code1[] = {0x00, 0x00, 0x01};
+    static char annexb_start_code2[] = {0x00, 0x00, 0x00, 0x01};
     bool first_nalu = true;
-    for (auto & nalu : nalus) {
+    for (auto &nalu : nalus) {
         if (first_nalu) {
             first_nalu = false;
             video_pes_segs_.emplace_back(std::string_view(annexb_start_code2, 4));
@@ -648,9 +656,9 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     }
 
     pes_packet->alloc_buf(video_pes_len);
-    for (auto & seg : video_pes_segs_) {
+    for (auto &seg : video_pes_segs_) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
     // 生成pes
@@ -661,23 +669,23 @@ bool FlvToTs::process_h265_packet(std::shared_ptr<FlvTag> video_pkt) {
     return true;
 }
 
-void FlvToTs::create_pat(std::string_view & data) {
-    uint8_t *buf = (uint8_t*)data.data();
+void FlvToTs::create_pat(std::string_view &data) {
+    uint8_t *buf = (uint8_t *)data.data();
     /*********************** ts header *********************/
-    *buf++ = 0x47;//ts header sync byte
+    *buf++ = 0x47;  // ts header sync byte
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TsPidPAT
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TsPidPAT;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
     // continuity_counter_(4b)   = 0
     *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | 00;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf++ = 0;
     uint8_t *pat_start = buf;
     // table_id
@@ -689,28 +697,32 @@ void FlvToTs::create_pat(std::string_view & data) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//transport_stream_id(2B) + current_next_indicator(1B) + section_number(1B) + last_section_number(1B) + crc
+    int16_t section_len = 5 + 4 + 4;  // transport_stream_id(2B) + current_next_indicator(1B) +
+                                      // section_number(1B) + last_section_number(1B) + crc
     int16_t slv = section_len & 0x0FFF;
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
-    //transport_stream_id
-    *((uint16_t*)buf) = htons(0x0001);//transport_stream_id
+    // transport_stream_id
+    *((uint16_t *)buf) = htons(0x0001);  // transport_stream_id
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf++ = cniv;
     // section_number
     *buf++ = 0;
@@ -723,25 +735,25 @@ void FlvToTs::create_pat(std::string_view & data) {
     v32 = (pmt_pid & 0x1FFF) | (0x07 << 13) | ((pmt_number << 16) & 0xFFFF0000);
     *((uint32_t *)buf) = htonl(v32);
     buf += 4;
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pat_start, buf - pat_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)data.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)data.data() + 188 - buf);
     return;
 }
 
-void FlvToTs::create_pmt(std::string_view & pmt_seg) {
-    uint8_t *buf = (uint8_t*)pmt_seg.data();
+void FlvToTs::create_pmt(std::string_view &pmt_seg) {
+    uint8_t *buf = (uint8_t *)pmt_seg.data();
     /*********************** ts header *********************/
-    *buf = 0x47;//ts header sync byte
+    *buf = 0x47;  // ts header sync byte
     buf++;
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TS_PMT_PID
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TS_PMT_PID;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
@@ -749,7 +761,7 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
     *buf = (TsAdapationControlPayloadOnly << 4);
     buf++;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf = 0;
     buf++;
     uint8_t *pmt_start = buf;
@@ -763,15 +775,19 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
+    int16_t section_len =
+        5 + 4 + 4;  // 5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
     if (has_video_) {
         section_len += 5;
     }
@@ -783,16 +799,16 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
 
     // program number
-    *((uint16_t*)buf) = htons(TS_PMT_NUMBER);//program number
+    *((uint16_t *)buf) = htons(TS_PMT_NUMBER);  // program number
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf = cniv;
     buf++;
     // section_number
@@ -801,30 +817,30 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
     // last_section_number
     *buf = 0;
     buf++;
-    // reserved 3 bslbf 
+    // reserved 3 bslbf
     // PCR_PID 13 uimsbf
     // 2B
     int16_t ppv = PCR_PID & 0x1FFF;
     ppv |= (7 << 13) & 0xE000;
-    *((uint16_t*)buf) = htons(ppv);
+    *((uint16_t *)buf) = htons(ppv);
     buf += 2;
-    // reserved 4 bslbf 
+    // reserved 4 bslbf
     // program_info_length 12 0
     // 2B
     int16_t pilv = 0 & 0xFFF;
     pilv |= (0xf << 12) & 0xF000;
-    *((uint16_t*)buf) = htons(pilv);
+    *((uint16_t *)buf) = htons(pilv);
     buf += 2;
-    // for (i = 0; i < N1; i++) { 
-    //     stream_type 8 uimsbf 
-    //     reserved 3 bslbf 
-    //     elementary_PID 13 uimsbf 
-        
-    //     reserved 4 bslbf 
-    //     ES_info_length 12 uimsbf 
-    //     for (i = 0; i < N2; i++) { 
-    //         descriptor() 
-    //     } 
+    // for (i = 0; i < N1; i++) {
+    //     stream_type 8 uimsbf
+    //     reserved 3 bslbf
+    //     elementary_PID 13 uimsbf
+
+    //     reserved 4 bslbf
+    //     ES_info_length 12 uimsbf
+    //     for (i = 0; i < N2; i++) {
+    //         descriptor()
+    //     }
     // }
 
     if (has_audio_) {
@@ -832,11 +848,11 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = audio_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
@@ -845,19 +861,19 @@ void FlvToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = video_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pmt_start, buf - pmt_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)pmt_seg.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)pmt_seg.data() + 188 - buf);
     return;
 }
 
@@ -872,11 +888,11 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
 
         uint8_t payload_unit_start_indicator = 0;
-        if (left_count == pes_len) {// 第一个ts切片，置上标志位
+        if (left_count == pes_len) {  // 第一个ts切片，置上标志位
             payload_unit_start_indicator = 1;
         }
         // transport_error_indicator(1b)        0
@@ -884,12 +900,11 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
         // transport_priority(1b)               0
         // pid(13b)                             TsPidPAT
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | video_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
 
-        
         bool write_pcr = false;
-        if (left_count == pes_len) {// 第一个切片
+        if (left_count == pes_len) {  // 第一个切片
             if (PCR_PID == video_pid_ && is_key) {
                 write_pcr = true;
             }
@@ -904,16 +919,17 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
         // adaptation_field_control(2b) = payload only
         // continuity_counter_(4b)   = 0
         if (write_pcr || write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
         }
         continuity_counter_[video_pid_]++;
 
         int adaptation_field_total_length = 0;
         if (write_pcr) {
             // adaptation_field_length
-            adaptation_field_total_length = 8;// adaptation_field_length(1) + flags(1) + PCR(6) = 8
+            adaptation_field_total_length = 8;  // adaptation_field_length(1) + flags(1) + PCR(6) = 8
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -924,14 +940,14 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
             if (staffing_count > 0) {
                 adaptation_field_total_length += staffing_count;
             }
-            int adaptation_field_length = adaptation_field_total_length - 1;// 需要减掉自己的1字节
+            int adaptation_field_length = adaptation_field_total_length - 1;  // 需要减掉自己的1字节
             *buf++ = adaptation_field_length;
-            *buf++ = 0x10;// (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
-            int64_t pcrv = (0) & 0x1ff;//program_clock_reference_base
-            pcrv |= (0x3f << 9) & 0x7E00;//reserved
+            *buf++ = 0x10;                 // (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
+            int64_t pcrv = (0) & 0x1ff;    // program_clock_reference_base
+            pcrv |= (0x3f << 9) & 0x7E00;  // reserved
             pcrv |= (pes_packet->pes_header.dts << 15) & 0xFFFFFFFF8000LL;
 
-            char *pp = (char*)&pcrv;
+            char *pp = (char *)&pcrv;
             *buf++ = pp[5];
             *buf++ = pp[4];
             *buf++ = pp[3];
@@ -945,7 +961,7 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
         }
 
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -958,7 +974,7 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -973,12 +989,12 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 video_pes_segs_[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -993,7 +1009,7 @@ void FlvToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pes
     pes_packet->ts_bytes = ts_total_bytes;
 }
 
-int32_t FlvToTs::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> & nalus) {
+int32_t FlvToTs::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> &nalus) {
     uint8_t *data_start = data;
     while (len > 0) {
         int32_t nalu_len = 0;
@@ -1016,7 +1032,7 @@ int32_t FlvToTs::get_nalus(uint8_t *data, int32_t len, std::list<std::string_vie
             return -2;
         }
 
-        nalus.emplace_back(std::string_view((char*)data, nalu_len));
+        nalus.emplace_back(std::string_view((char *)data, nalu_len));
         data += nalu_len;
         len -= nalu_len;
     }
@@ -1041,20 +1057,21 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
     AudioTagHeader header;
     auto payload = audio_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
-    AACCodec *aac_codec = ((AACCodec*)audio_codec_.get());
+    AACCodec *aac_codec = ((AACCodec *)audio_codec_.get());
     bool sequence_header = false;
-    
-    if (header.is_seq_header()) {// 关键帧索引
+
+    if (header.is_seq_header()) {  // 关键帧索引
         audio_ready_ = true;
         audio_header_ = audio_pkt;
         sequence_header = true;
         // 解析aac configuration header
         std::shared_ptr<AudioSpecificConfig> audio_config = std::make_shared<AudioSpecificConfig>();
-        int32_t consumed = audio_config->parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = audio_config->parse((uint8_t *)payload.data() + header_consumed,
+                                               payload.size() - header_consumed);
         if (consumed < 0) {
             CORE_ERROR("parse aac audio header failed, ret:{}", consumed);
             return false;
@@ -1072,19 +1089,15 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
         return false;
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     if (curr_seg_) {
         if (publish_app_->can_reap_ts(false, curr_seg_)) {
-            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by audio", 
-                            get_session_name(), 
-                            curr_seg_->get_seqno(),
-                            curr_seg_->get_filename(),
-                            curr_seg_->get_ts_bytes()/1024,
-                            curr_seg_->get_duration()
-            );
+            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by audio", get_session_name(),
+                     curr_seg_->get_seqno(), curr_seg_->get_filename(), curr_seg_->get_ts_bytes() / 1024,
+                     curr_seg_->get_duration());
             on_ts_segment(curr_seg_);
             curr_seg_ = nullptr;
         }
@@ -1110,7 +1123,7 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
 
     int32_t audio_payload_size = payload.size() - header_consumed;
     int32_t frame_length = 7 + audio_payload_size;
-    auto & adts_header = adts_headers_[adts_header_index_];
+    auto &adts_header = adts_headers_[adts_header_index_];
     adts_header.data[0] = 0xff;
     adts_header.data[1] = 0xf9;
     adts_header.data[2] = (aac_profile << 6) & 0xc0;
@@ -1129,11 +1142,12 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
     adts_header.data[6] = 0xfc;
     // uint8_t adts_header[7] = { 0xff, 0xf9, 0x00, 0x00, 0x00, 0x0f, 0xfc };
     adts_header_index_++;
-    
+
     audio_buf_.audio_pes_segs.emplace_back(std::string_view(adts_header.data, 7));
-    audio_buf_.audio_pes_segs.emplace_back(std::string_view(payload.data() + header_consumed, audio_payload_size));
+    audio_buf_.audio_pes_segs.emplace_back(
+        std::string_view(payload.data() + header_consumed, audio_payload_size));
     audio_buf_.audio_pes_len += (7 + audio_payload_size);
-    if (audio_buf_.audio_pes_len < 1400) {//至少1400字节，再一起送切片
+    if (audio_buf_.audio_pes_len < 1400) {  // 至少1400字节，再一起送切片
         return true;
     }
 
@@ -1154,32 +1168,32 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
     pes_header.stream_id = TsPESStreamIdAudioCommon;
     *pes++ = TsPESStreamIdAudioCommon;
     uint8_t PTS_DTS_flags = 0x02;
-    uint8_t PES_header_data_length = 5;//只有pts
+    uint8_t PES_header_data_length = 5;  // 只有pts
     // int32_t payload_size = 7 + payload.size() - header_consumed;//adts header + payload
     int32_t payload_size = audio_buf_.audio_pes_len;
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes_header.PES_packet_length = PES_packet_length;
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    //audio pts
-    uint64_t dts = audio_buf_.timestamp*90;
+    // audio pts
+    uint64_t dts = audio_buf_.timestamp * 90;
     pes_header.dts = dts;
     int32_t val = 0;
     val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
@@ -1189,10 +1203,10 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
     *pes++ = (val >> 8);
     *pes++ = val;
 
-    val = int32_t((((dts)&0x7fff) << 1) | 1);
+    val = int32_t((((dts) & 0x7fff) << 1) | 1);
     *pes++ = (val >> 8);
     *pes++ = val;
-    
+
     // // audio pts end
     // uint8_t adts_header[7] = { 0xff, 0xf9, 0x00, 0x00, 0x00, 0x0f, 0xfc };
     // AudioSpecificConfig & audio_config = aac_codec->getAudioSpecificConfig();
@@ -1234,11 +1248,11 @@ bool FlvToTs::process_aac_packet(std::shared_ptr<FlvTag> audio_pkt) {
     for (auto seg : audio_buf_.audio_pes_segs) {
         audio_pes_bytes += seg.size();
     }
-    
+
     pes_packet->alloc_buf(audio_pes_bytes);
     for (auto seg : audio_buf_.audio_pes_segs) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
 
@@ -1254,31 +1268,28 @@ bool FlvToTs::process_mp3_packet(std::shared_ptr<FlvTag> audio_pkt) {
     AudioTagHeader header;
     auto payload = audio_pkt->get_using_data();
     payload.remove_prefix(FLV_TAG_HEADER_BYTES);
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     if (curr_seg_) {
         if (publish_app_->can_reap_ts(false, curr_seg_)) {
-            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by audio", 
-                            get_session_name(), 
-                            curr_seg_->get_seqno(),
-                            curr_seg_->get_filename(),
-                            curr_seg_->get_ts_bytes()/1024,
-                            curr_seg_->get_duration()
-            );
+            HLS_INFO("session:{}, reap ts seq:{}, name:{}, bytes:{}k, dur:{} by audio", get_session_name(),
+                     curr_seg_->get_seqno(), curr_seg_->get_filename(), curr_seg_->get_ts_bytes() / 1024,
+                     curr_seg_->get_duration());
             on_ts_segment(curr_seg_);
             curr_seg_ = nullptr;
         }
     }
 
     int32_t audio_payload_size = payload.size() - header_consumed;
-    audio_buf_.audio_pes_segs.emplace_back(std::string_view(payload.data() + header_consumed, audio_payload_size));
+    audio_buf_.audio_pes_segs.emplace_back(
+        std::string_view(payload.data() + header_consumed, audio_payload_size));
     audio_buf_.audio_pes_len += audio_payload_size;
 
     if (!curr_seg_) {
@@ -1297,32 +1308,32 @@ bool FlvToTs::process_mp3_packet(std::shared_ptr<FlvTag> audio_pkt) {
     pes_header.stream_id = TsPESStreamIdAudioCommon;
     *pes++ = TsPESStreamIdAudioCommon;
     uint8_t PTS_DTS_flags = 0x02;
-    uint8_t PES_header_data_length = 5;//只有pts
+    uint8_t PES_header_data_length = 5;  // 只有pts
 
     int32_t payload_size = audio_buf_.audio_pes_len;
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes_header.PES_packet_length = PES_packet_length;
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    //audio pts
-    uint64_t dts = audio_pkt->tag_header.timestamp*90;
+    // audio pts
+    uint64_t dts = audio_pkt->tag_header.timestamp * 90;
     pes_header.dts = dts;
     int32_t val = 0;
     val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
@@ -1332,10 +1343,10 @@ bool FlvToTs::process_mp3_packet(std::shared_ptr<FlvTag> audio_pkt) {
     *pes++ = (val >> 8);
     *pes++ = val;
 
-    val = int32_t((((dts)&0x7fff) << 1) | 1);
+    val = int32_t((((dts) & 0x7fff) << 1) | 1);
     *pes++ = (val >> 8);
     *pes++ = val;
-    
+
     int32_t pes_header_len = pes - audio_pes_header_;
     audio_buf_.audio_pes_len += pes_header_len;
     audio_buf_.audio_pes_segs[0] = std::string_view(audio_pes_header_, pes_header_len);
@@ -1344,11 +1355,11 @@ bool FlvToTs::process_mp3_packet(std::shared_ptr<FlvTag> audio_pkt) {
     for (auto seg : audio_buf_.audio_pes_segs) {
         audio_pes_bytes += seg.size();
     }
-    
+
     pes_packet->alloc_buf(audio_pes_bytes);
     for (auto seg : audio_buf_.audio_pes_segs) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
 
@@ -1371,8 +1382,8 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
         // transport_error_indicator(1b)        0
         // payload_unit_start_indicator(1b)     1
         // transport_priority(1b)               0
@@ -1382,7 +1393,7 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             payload_unit_start_indicator = 1;
         }
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | audio_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
         // transport_scrambling_control(2b) = 00
         // adaptation_field_control(2b) = payload only
@@ -1393,15 +1404,16 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         }
 
         if (write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         }
 
         continuity_counter_[audio_pid_]++;
         int adaptation_field_total_length = 0;
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -1414,7 +1426,7 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -1430,12 +1442,12 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 audio_buf_.audio_pes_segs[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -1447,10 +1459,7 @@ void FlvToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
     pes_packet->ts_bytes = ts_total_bytes;
 }
 
-
-void FlvToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) {
-    ts_media_source_->on_ts_segment(seg);
-}
+void FlvToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) { ts_media_source_->on_ts_segment(seg); }
 
 void FlvToTs::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
@@ -1458,28 +1467,31 @@ void FlvToTs::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (ts_media_source_) {
-            ts_media_source_->close();
-            ts_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (flv_media_sink_) {
-            flv_media_sink_->on_flv_tag({});
-            flv_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(flv_media_sink_);
+            if (ts_media_source_) {
+                ts_media_source_->close();
+                ts_media_source_ = nullptr;
             }
-            flv_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (flv_media_sink_) {
+                flv_media_sink_->on_flv_tag({});
+                flv_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(flv_media_sink_);
+                }
+                flv_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/mp4/mp4_to_mpd.cpp
+++ b/live-server/bridge/mp4/mp4_to_mpd.cpp
@@ -3,82 +3,99 @@
  * @Date: 2023-07-02 10:56:59
  * @LastEditTime: 2023-12-27 20:04:26
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\ts_to_hls.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "mp4_to_mpd.hpp"
+
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
 #include <boost/asio/redirect_error.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/asio/detached.hpp>
 
-#include "mp4_to_mpd.hpp"
+#include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
+#include "config/app_config.h"
 #include "core/mp4_media_sink.hpp"
 #include "core/mpd_live_media_source.hpp"
 #include "log/log.h"
-#include "app/publish_app.h"
-#include "config/app_config.h"
+
 
 using namespace mms;
 
-Mp4ToMpd::Mp4ToMpd(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
+Mp4ToMpd::Mp4ToMpd(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                   std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                   const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
     sink_ = std::make_shared<Mp4MediaSink>(worker);
     mp4_media_sink_ = std::static_pointer_cast<Mp4MediaSink>(sink_);
-    source_ = std::make_shared<MpdLiveMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<MpdLiveMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     mpd_media_source_ = std::static_pointer_cast<MpdLiveMediaSource>(source_);
 }
 
-Mp4ToMpd::~Mp4ToMpd() {
-
-}
+Mp4ToMpd::~Mp4ToMpd() {}
 
 bool Mp4ToMpd::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
+
+                if (mpd_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    CORE_DEBUG("close Mp4ToMpd because no players for {}s",
+                               app_conf->bridge_config().no_players_timeout_ms() / 1000);
+                    break;
+                }
             }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-            if (mpd_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                CORE_DEBUG("close Mp4ToMpd because no players for {}s", app_conf->bridge_config().no_players_timeout_ms()/1000);
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+    mp4_media_sink_->set_audio_init_segment_cb(
+        [this, self](std::shared_ptr<Mp4Segment> seg) -> boost::asio::awaitable<bool> {
+            mpd_media_source_->on_audio_init_segment(seg);
+            co_return true;
+        });
 
-    mp4_media_sink_->set_audio_init_segment_cb([this, self](std::shared_ptr<Mp4Segment> seg)->boost::asio::awaitable<bool> {
-        mpd_media_source_->on_audio_init_segment(seg);
-        co_return true;
-    });
+    mp4_media_sink_->set_video_init_segment_cb(
+        [this, self](std::shared_ptr<Mp4Segment> seg) -> boost::asio::awaitable<bool> {
+            mpd_media_source_->on_video_init_segment(seg);
+            co_return true;
+        });
 
-    mp4_media_sink_->set_video_init_segment_cb([this, self](std::shared_ptr<Mp4Segment> seg)->boost::asio::awaitable<bool> {
-        mpd_media_source_->on_video_init_segment(seg);
-        co_return true;
-    });
+    mp4_media_sink_->set_audio_mp4_segment_cb(
+        [this, self](std::shared_ptr<Mp4Segment> seg) -> boost::asio::awaitable<bool> {
+            mpd_media_source_->on_audio_segment(seg);
+            co_return true;
+        });
 
-    mp4_media_sink_->set_audio_mp4_segment_cb([this, self](std::shared_ptr<Mp4Segment> seg)->boost::asio::awaitable<bool> {
-        mpd_media_source_->on_audio_segment(seg);
-        co_return true;
-    });
-
-    mp4_media_sink_->set_video_mp4_segment_cb([this, self](std::shared_ptr<Mp4Segment> seg)->boost::asio::awaitable<bool> {
-        mpd_media_source_->on_video_segment(seg);
-        co_return true;
-    });
-    return true;    
+    mp4_media_sink_->set_video_mp4_segment_cb(
+        [this, self](std::shared_ptr<Mp4Segment> seg) -> boost::asio::awaitable<bool> {
+            mpd_media_source_->on_video_segment(seg);
+            co_return true;
+        });
+    return true;
 }
 
 void Mp4ToMpd::close() {
@@ -87,27 +104,30 @@ void Mp4ToMpd::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
-        
-        if (mpd_media_source_) {
-            mpd_media_source_->close();
-            mpd_media_source_ = nullptr;
-        }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        auto origin_source = origin_source_.lock();
-        if (mp4_media_sink_) {
-            mp4_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(mp4_media_sink_);
+            if (mpd_media_source_) {
+                mpd_media_source_->close();
+                mpd_media_source_ = nullptr;
             }
-            mp4_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (mp4_media_sink_) {
+                mp4_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(mp4_media_sink_);
+                }
+                mp4_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/rtmp/rtmp_to_flv.cpp
+++ b/live-server/bridge/rtmp/rtmp_to_flv.cpp
@@ -1,87 +1,103 @@
-#include <memory>
+#include "rtmp_to_flv.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <memory>
 
-#include "log/log.h"
-#include "rtmp_to_flv.hpp"
-#include "base/thread/thread_worker.hpp"
-#include "core/flv_media_source.hpp"
 #include "app/publish_app.h"
+#include "base/thread/thread_worker.hpp"
 #include "config/app_config.h"
+#include "core/flv_media_source.hpp"
+#include "log/log.h"
+
 
 using namespace mms;
 
-RtmpToFlv::RtmpToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<FlvMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+RtmpToFlv::RtmpToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                     std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                     const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<FlvMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     flv_media_source_ = std::static_pointer_cast<FlvMediaSource>(source_);
-    sink_ = std::make_shared<RtmpMediaSink>(worker); 
+    sink_ = std::make_shared<RtmpMediaSink>(worker);
     rtmp_media_sink_ = std::static_pointer_cast<RtmpMediaSink>(sink_);
     type_ = "rtmp-to-flv";
 }
 
-RtmpToFlv::~RtmpToFlv() {
-    CORE_DEBUG("destroy RtmpToFlv");
-}
+RtmpToFlv::~RtmpToFlv() { CORE_DEBUG("destroy RtmpToFlv"); }
 
 bool RtmpToFlv::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//10s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
-
-            if (flv_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经10秒没人播放了
-                CORE_DEBUG("close RtmpToFlv because no players for 10s");
-                close();
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)(exp);
-        wg_.done();
-    });
-
-    rtmp_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        flv_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            rtmp_media_sink_->on_rtmp_message([this, self](const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs)->boost::asio::awaitable<bool> {
-                for (auto rtmp_msg : rtmp_msgs) {
-                    if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
-                        if (!this->on_audio_packet(rtmp_msg)) {
-                            co_return false;
-                        }
-                    } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
-                        if (!this->on_video_packet(rtmp_msg)) {
-                            co_return false;
-                        }
-                    } else {
-                        if (!this->on_metadata(rtmp_msg)) {
-                            co_return false;
-                        }
-                    }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 10s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
                 }
-                
-                co_return true;
-            });
-        }
-        co_return;
-    });
-    
+
+                if (flv_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经10秒没人播放了
+                    CORE_DEBUG("close RtmpToFlv because no players for 10s");
+                    close();
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)(exp);
+            wg_.done();
+        });
+
+    rtmp_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            flv_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                rtmp_media_sink_->on_rtmp_message(
+                    [this, self](const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs)
+                        -> boost::asio::awaitable<bool> {
+                        for (auto rtmp_msg : rtmp_msgs) {
+                            if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
+                                if (!this->on_audio_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
+                                if (!this->on_video_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else {
+                                if (!this->on_metadata(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            }
+                        }
+
+                        co_return true;
+                    });
+            }
+            co_return;
+        });
+
     return true;
 }
 
 bool RtmpToFlv::on_metadata(std::shared_ptr<RtmpMessage> rtmp_metadata_pkt) {
     auto metadata_pkt_using_data = rtmp_metadata_pkt->get_using_data();
-    std::shared_ptr<FlvTag> script_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + metadata_pkt_using_data.size());
+    std::shared_ptr<FlvTag> script_flv_tag =
+        std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + metadata_pkt_using_data.size());
     script_flv_tag->tag_header.data_size = metadata_pkt_using_data.size();
     script_flv_tag->tag_header.stream_id = rtmp_metadata_pkt->message_stream_id_;
     script_flv_tag->tag_header.tag_type = FlvTagHeader::ScriptTag;
@@ -93,20 +109,21 @@ bool RtmpToFlv::on_metadata(std::shared_ptr<RtmpMessage> rtmp_metadata_pkt) {
 
     script_flv_tag->encode();
     return flv_media_source_->on_metadata(script_flv_tag);
-} 
+}
 
 bool RtmpToFlv::on_audio_packet(std::shared_ptr<RtmpMessage> audio_pkt) {
     auto audio_pkt_using_data = audio_pkt->get_using_data();
-    std::shared_ptr<FlvTag> audio_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + audio_pkt_using_data.size());
-    
+    std::shared_ptr<FlvTag> audio_flv_tag =
+        std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + audio_pkt_using_data.size());
+
     audio_flv_tag->tag_header.data_size = audio_pkt_using_data.size();
     audio_flv_tag->tag_header.stream_id = audio_pkt->message_stream_id_;
-    audio_flv_tag->tag_header.tag_type  = FlvTagHeader::AudioTag;
+    audio_flv_tag->tag_header.tag_type = FlvTagHeader::AudioTag;
     audio_flv_tag->tag_header.timestamp = audio_pkt->timestamp_;
 
     auto audio_data = std::make_unique<AUDIODATA>();
     audio_data->payload = audio_pkt_using_data;
-    audio_data->decode((const uint8_t*)audio_pkt_using_data.data(), audio_pkt_using_data.size());
+    audio_data->decode((const uint8_t *)audio_pkt_using_data.data(), audio_pkt_using_data.size());
     audio_flv_tag->tag_data = std::move(audio_data);
 
     audio_flv_tag->encode();
@@ -116,13 +133,15 @@ bool RtmpToFlv::on_audio_packet(std::shared_ptr<RtmpMessage> audio_pkt) {
 bool RtmpToFlv::on_video_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     auto video_pkt_using_data = video_pkt->get_using_data();
     VideoTagHeader header;
-    int32_t header_consumed = header.decode((uint8_t*)video_pkt_using_data.data(), video_pkt_using_data.size());
+    int32_t header_consumed =
+        header.decode((uint8_t *)video_pkt_using_data.data(), video_pkt_using_data.size());
     if (header_consumed < 0) {
         return false;
     }
 
-    std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + video_pkt_using_data.size());
-    
+    std::shared_ptr<FlvTag> video_flv_tag =
+        std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + video_pkt_using_data.size());
+
     video_flv_tag->tag_header.data_size = video_pkt_using_data.size();
     video_flv_tag->tag_header.stream_id = video_pkt->message_stream_id_;
     video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
@@ -130,7 +149,7 @@ bool RtmpToFlv::on_video_packet(std::shared_ptr<RtmpMessage> video_pkt) {
 
     auto video_data = std::make_unique<VIDEODATA>();
     video_data->payload = video_pkt_using_data;
-    video_data->decode((uint8_t*)video_pkt_using_data.data(), video_pkt_using_data.size());
+    video_data->decode((uint8_t *)video_pkt_using_data.data(), video_pkt_using_data.size());
     video_flv_tag->tag_data = std::move(video_data);
 
     video_flv_tag->encode();
@@ -143,28 +162,31 @@ void RtmpToFlv::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (flv_media_source_) {
-            flv_media_source_->close();
-            flv_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtmp_media_sink_) {
-            rtmp_media_sink_->on_rtmp_message({});
-            rtmp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtmp_media_sink_);
+            if (flv_media_source_) {
+                flv_media_source_->close();
+                flv_media_source_ = nullptr;
             }
-            rtmp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtmp_media_sink_) {
+                rtmp_media_sink_->on_rtmp_message({});
+                rtmp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtmp_media_sink_);
+                }
+                rtmp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/rtmp/rtmp_to_mp4.cpp
+++ b/live-server/bridge/rtmp/rtmp_to_mp4.cpp
@@ -3,147 +3,154 @@
  * @Date: 2023-11-09 20:49:39
  * @LastEditTime: 2023-11-09 20:51:27
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\rtmp_to_ts.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "rtmp_to_mp4.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
-
+#include <boost/asio/use_awaitable.hpp>
 #include <fstream>
-#include "log/log.h"
-#include "rtmp_to_mp4.hpp"
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/ts/ts_pat_pmt.hpp"
-#include "protocol/ts/ts_header.hpp"
-#include "protocol/ts/ts_segment.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
 
+#include "app/publish_app.h"
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
+#include "codec/av1/av1_codec.hpp"
 #include "codec/h264/h264_codec.hpp"
 #include "codec/hevc/hevc_codec.hpp"
-#include "codec/av1/av1_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
 #include "codec/mp3/mp3_codec.hpp"
-#include "codec/aac/adts.hpp"
-
-#include "base/utils/utils.h"
-#include "app/publish_app.h"
 #include "config/app_config.h"
-
-
-#include "mp4/moov.h"
-#include "mp4/mvhd.h"
-#include "mp4/ftyp.h"
-#include "mp4/trak.h"
-#include "mp4/tkhd.h"
-#include "mp4/mdia.h"
-#include "mp4/mdhd.h"
-#include "mp4/hdlr.h"
-#include "mp4/minf.h"
-#include "mp4/vmhd.h"
+#include "core/mp4_media_source.hpp"
+#include "log/log.h"
+#include "mp4/audio_sample_entry.h"
+#include "mp4/avcc.h"
 #include "mp4/dinf.h"
 #include "mp4/dref.h"
-#include "mp4/stbl.h"
-#include "mp4/stsd.h"
-#include "mp4/visual_sample_entry.h"
-#include "mp4/avcc.h"
-#include "mp4/stss.h"
-#include "mp4/stts.h"
-#include "mp4/stsc.h"
-#include "mp4/stsz.h"
-#include "mp4/stco.h"
-#include "mp4/mvex.h"
-#include "mp4/trex.h"
-#include "mp4/url.h"
-#include "mp4/audio_sample_entry.h"
 #include "mp4/esds.h"
-#include "mp4/styp.h"
-#include "mp4/sidx.h"
-#include "mp4/mdia.h"
+#include "mp4/ftyp.h"
+#include "mp4/hdlr.h"
 #include "mp4/mdat.h"
-#include "mp4/moof.h"
+#include "mp4/mdhd.h"
+#include "mp4/mdia.h"
 #include "mp4/mfhd.h"
-#include "mp4/tfhd.h"
+#include "mp4/minf.h"
+#include "mp4/moof.h"
+#include "mp4/moov.h"
+#include "mp4/mvex.h"
+#include "mp4/mvhd.h"
+#include "mp4/sidx.h"
+#include "mp4/stbl.h"
+#include "mp4/stco.h"
+#include "mp4/stsc.h"
+#include "mp4/stsd.h"
+#include "mp4/stss.h"
+#include "mp4/stsz.h"
+#include "mp4/stts.h"
+#include "mp4/styp.h"
 #include "mp4/tfdt.h"
-#include "mp4/trun.h"
+#include "mp4/tfhd.h"
+#include "mp4/tkhd.h"
 #include "mp4/traf.h"
+#include "mp4/trak.h"
+#include "mp4/trex.h"
+#include "mp4/trun.h"
+#include "mp4/url.h"
+#include "mp4/visual_sample_entry.h"
+#include "mp4/vmhd.h"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/ts/ts_header.hpp"
+#include "protocol/ts/ts_pat_pmt.hpp"
+#include "protocol/ts/ts_segment.hpp"
 
-
-#include "core/mp4_media_source.hpp"
 
 using namespace mms;
-RtmpToMp4::RtmpToMp4(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
+RtmpToMp4::RtmpToMp4(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                     std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                     const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
     sink_ = std::make_shared<RtmpMediaSink>(worker);
     rtmp_media_sink_ = std::static_pointer_cast<RtmpMediaSink>(sink_);
-    source_ = std::make_shared<Mp4MediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<Mp4MediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     mp4_media_source_ = std::static_pointer_cast<Mp4MediaSource>(source_);
     CORE_DEBUG("create rtmp to mp4");
     type_ = "rtmp-to-mp4";
 }
 
-RtmpToMp4::~RtmpToMp4() {
-
-}
+RtmpToMp4::~RtmpToMp4() {}
 
 bool RtmpToMp4::init() {
     auto self(shared_from_this());
 
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
-
-            if (mp4_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                CORE_DEBUG("close RtmpToMp4 because no players for {}ms", app_conf->bridge_config().no_players_timeout_ms());
-                close();
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-    });
-
-    rtmp_media_sink_->on_close([this, self]() {
-        close();
-    });
-
-    rtmp_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        mp4_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            rtmp_media_sink_->on_rtmp_message([this, self](const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs)->boost::asio::awaitable<bool> {
-                for (auto rtmp_msg : rtmp_msgs) {
-                    if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
-                        if (!this->on_audio_packet(rtmp_msg)) {
-                            co_return false;
-                        }
-                    } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
-                        if (!this->on_video_packet(rtmp_msg)) {
-                            co_return false;
-                        }
-                    } else {
-                        if (!this->on_metadata(rtmp_msg)) {
-                            co_return false;
-                        }
-                    }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
                 }
-                
-                co_return true;
-            });
-        }
-        co_return;
-    });
+
+                if (mp4_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    CORE_DEBUG("close RtmpToMp4 because no players for {}ms",
+                               app_conf->bridge_config().no_players_timeout_ms());
+                    close();
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+        });
+
+    rtmp_media_sink_->on_close([this, self]() { close(); });
+
+    rtmp_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            mp4_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                rtmp_media_sink_->on_rtmp_message(
+                    [this, self](const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs)
+                        -> boost::asio::awaitable<bool> {
+                        for (auto rtmp_msg : rtmp_msgs) {
+                            if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
+                                if (!this->on_audio_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
+                                if (!this->on_video_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else {
+                                if (!this->on_metadata(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            }
+                        }
+
+                        co_return true;
+                    });
+            }
+            co_return;
+        });
     return true;
 }
 
@@ -184,10 +191,11 @@ bool RtmpToMp4::on_video_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     if (!video_codec_) {
         VideoTagHeader header;
         auto payload = video_pkt->get_using_data();
-        header.decode((uint8_t*)payload.data(), payload.size());
+        header.decode((uint8_t *)payload.data(), payload.size());
         if (header.get_codec_id() == VideoTagHeader::AVC) {
             video_codec_ = std::make_shared<H264Codec>();
-        } else if (header.get_codec_id() == VideoTagHeader::HEVC || header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
+        } else if (header.get_codec_id() == VideoTagHeader::HEVC ||
+                   header.get_codec_id() == VideoTagHeader::HEVC_FOURCC) {
             video_codec_ = std::make_shared<HevcCodec>();
         } else {
             return false;
@@ -199,40 +207,42 @@ bool RtmpToMp4::on_video_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         return process_h265_packet(video_pkt);
     }
-    
+
     return false;
 }
 
 bool RtmpToMp4::process_h264_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
 
-    H264Codec *h264_codec = ((H264Codec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    H264Codec *h264_codec = ((H264Codec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析avc configuration heade
         AVCDecoderConfigurationRecord avc_decoder_configuration_record;
-        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t *)payload.data() + header_consumed,
+                                                                  payload.size() - header_consumed);
         if (consumed < 0) {
             return false;
         }
 
-        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(), avc_decoder_configuration_record.get_pps());
+        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(),
+                                avc_decoder_configuration_record.get_pps());
         nalu_length_size_ = avc_decoder_configuration_record.nalu_length_size_minus_one + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
             return false;
         }
         generate_video_init_seg(video_pkt);
         return true;
-    } 
+    }
 
     bool is_key = header.is_key_frame() && !header.is_seq_header();
-    if (video_pkts_.size() <= 0 && !is_key) {//片段开始的帧，必须是关键帧
+    if (video_pkts_.size() <= 0 && !is_key) {  // 片段开始的帧，必须是关键帧
         return false;
     }
 
@@ -257,7 +267,7 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
     video_data_mp4_seg_ = std::make_shared<Mp4Segment>();
     std::stringstream ss;
     ss << "video-" << video_seq_no_ << ".m4s";
-    std::ofstream of(ss.str(), std::ios::out|std::ios::binary);
+    std::ofstream of(ss.str(), std::ios::out | std::ios::binary);
     StypBox styp;
     styp.major_brand_ = Mp4BoxBrandMSDH;
     styp.minor_version_ = 0;
@@ -266,7 +276,6 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
     size_t s = styp.size();
     NetBuffer n(video_data_mp4_seg_->alloc_buffer(s));
     styp.encode(n);
-
 
     auto sidx = std::make_shared<SidxBox>();
     sidx->version_ = 1;
@@ -296,15 +305,12 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
     traf->tfhd_ = tfhd;
 
     auto tfdt = std::make_shared<TfdtBox>();
-    tfdt->base_media_decode_time = 1;//in ms
+    tfdt->base_media_decode_time = 1;  // in ms
     tfdt->version_ = 1;
     traf->tfdt_ = tfdt;
 
     auto trun = std::make_shared<TrunBox>(0);
-    trun->flags_ = TrunFlagsDataOffset | 
-                   TrunFlagsSampleDuration | 
-                   TrunFlagsSampleSize | 
-                   TrunFlagsSampleFlag | 
+    trun->flags_ = TrunFlagsDataOffset | TrunFlagsSampleDuration | TrunFlagsSampleSize | TrunFlagsSampleFlag |
                    TrunFlagsSampleCtsOffset;
     traf->trun_ = trun;
     trun->entries_.reserve(video_pkts_.size());
@@ -325,10 +331,10 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
         } else {
             te.sample_duration_ = (*it_next)->timestamp_ - (*it)->timestamp_;
         }
-        
+
         auto payload = (*it)->get_using_data();
         VideoTagHeader header;
-        int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+        int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
         te.sample_size_ = payload.size() - header_consumed;
         te.sample_composition_time_offset_ = header.composition_time;
         if (te.sample_composition_time_offset_ < 0) {
@@ -342,8 +348,8 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
     int64_t moof_bytes = moof->size();
     trun->data_offset_ = (int32_t)(moof_bytes + mdat->size());
     // Update the size of sidx.
-    SegmentIndexEntry* e = &sidx->entries[0];
-    e->referenced_size = moof_bytes +  mdat->size() + mdat_bytes;
+    SegmentIndexEntry *e = &sidx->entries[0];
+    e->referenced_size = moof_bytes + mdat->size() + mdat_bytes;
     s = sidx->size();
     n = NetBuffer(video_data_mp4_seg_->alloc_buffer(s));
     sidx->encode(n);
@@ -352,20 +358,21 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
     n = NetBuffer(video_data_mp4_seg_->alloc_buffer(s));
     moof->encode(n);
 
-    {//写mdat
+    {  // 写mdat
         s = mdat->size();
         n = NetBuffer(video_data_mp4_seg_->alloc_buffer(s));
         mdat->encode(n);
         for (auto it = video_pkts_.begin(); it != video_pkts_.end(); it++) {
             auto payload = (*it)->get_using_data();
             VideoTagHeader header;
-            int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+            int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
             auto frame_bytes = payload.size() - header_consumed;
             n = NetBuffer(video_data_mp4_seg_->alloc_buffer(frame_bytes));
-            memcpy((char*)n.get_curr_buf().data(), payload.data() + header_consumed, frame_bytes);
+            memcpy((char *)n.get_curr_buf().data(), payload.data() + header_consumed, frame_bytes);
         }
     }
-    video_data_mp4_seg_->update_timestamp(video_pkts_[0]->timestamp_, video_pkts_[video_pkts_.size()-1]->timestamp_);
+    video_data_mp4_seg_->update_timestamp(video_pkts_[0]->timestamp_,
+                                          video_pkts_[video_pkts_.size() - 1]->timestamp_);
     video_data_mp4_seg_->set_seqno(video_seq_no_);
     video_data_mp4_seg_->set_filename("video-" + std::to_string(video_seq_no_++) + ".m4s");
     auto used_buf = video_data_mp4_seg_->get_used_buf();
@@ -375,8 +382,8 @@ void RtmpToMp4::reap_video_seg(int64_t dts) {
 
 bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) {
     (void)video_pkt;
-    std::ofstream of("./video-init.mp4", std::ios::out|std::ios::binary);
-    H264Codec *h264_codec = ((H264Codec*)video_codec_.get());
+    std::ofstream of("./video-init.mp4", std::ios::out | std::ios::binary);
+    H264Codec *h264_codec = ((H264Codec *)video_codec_.get());
 
     init_video_mp4_seg_ = std::make_shared<Mp4Segment>();
     FtypBox ftyp;
@@ -387,7 +394,7 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
     size_t s = ftyp.size();
     NetBuffer n(init_video_mp4_seg_->alloc_buffer(s));
     ftyp.encode(n);
-    
+
     video_moov_ = std::make_shared<MoovBox>();
     std::shared_ptr<MvhdBox> mvhd = std::make_shared<MvhdBox>();
     mvhd->creation_time_ = time(NULL);
@@ -396,14 +403,14 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
     mvhd->next_track_ID_ = video_track_ID_ + 1;
     video_moov_->add_box(mvhd);
     {
-        //trak
+        // trak
         auto trak = std::make_shared<TrakBox>();
         video_moov_->add_box(trak);
         // tkhd
         auto tkhd = std::make_shared<TkhdBox>(0, 0x03);
         tkhd->track_ID_ = video_track_ID_;
         tkhd->duration_ = 0;
-        uint32_t w,h;
+        uint32_t w, h;
         h264_codec->get_wh(w, h);
         tkhd->width_ = (w << 16);
         tkhd->height_ = (h << 16);
@@ -442,7 +449,6 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
 
                 auto stbl = std::make_shared<StblBox>();
                 {
-                    
                     auto stts = std::make_shared<SttsBox>();
                     stbl->add_box(stts);
                     auto stsc = std::make_shared<StscBox>();
@@ -461,22 +467,20 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
                         avc1->data_reference_index_ = 1;
 
                         auto avcc = std::make_shared<AvccBox>();
-                        auto & avc_config = h264_codec->get_avc_configuration();
+                        auto &avc_config = h264_codec->get_avc_configuration();
                         auto avc_size = avc_config.size();
                         std::string avc_raw_data;
                         avc_raw_data.resize(avc_size);
-                        avc_config.encode((uint8_t*)avc_raw_data.data(), avc_raw_data.size());
+                        avc_config.encode((uint8_t *)avc_raw_data.data(), avc_raw_data.size());
                         avcc->avc_config_ = avc_raw_data;
                         avc1->set_avcc_box(avcc);
                     }
                     stbl->add_box(stsd);
-                    
                 }
                 minf->add_box(stbl);
             }
             mdia->set_minf(minf);
-        }   
-
+        }
     }
 
     auto mvex = std::make_shared<MvexBox>();
@@ -485,7 +489,7 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
     trex->default_sample_description_index_ = 1;
     mvex->set_trex(trex);
     video_moov_->add_box(mvex);
-    
+
     video_moov_->size();
     n = NetBuffer(init_video_mp4_seg_->alloc_buffer(video_moov_->size()));
     video_moov_->encode(n);
@@ -498,7 +502,7 @@ bool RtmpToMp4::generate_video_init_seg(std::shared_ptr<RtmpMessage> video_pkt) 
 }
 
 bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) {
-    std::ofstream of("./audio-init.mp4", std::ios::out|std::ios::binary);
+    std::ofstream of("./audio-init.mp4", std::ios::out | std::ios::binary);
 
     init_audio_mp4_seg_ = std::make_shared<Mp4Segment>();
     FtypBox ftyp;
@@ -509,7 +513,7 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
     size_t s = ftyp.size();
     NetBuffer n(init_audio_mp4_seg_->alloc_buffer(s));
     ftyp.encode(n);
-    
+
     video_moov_ = std::make_shared<MoovBox>();
     std::shared_ptr<MvhdBox> mvhd = std::make_shared<MvhdBox>();
     mvhd->creation_time_ = time(NULL);
@@ -518,7 +522,7 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
     mvhd->next_track_ID_ = audio_track_ID_ + 1;
     video_moov_->add_box(mvhd);
     {
-        //trak
+        // trak
         auto trak = std::make_shared<TrakBox>();
         video_moov_->add_box(trak);
         // tkhd
@@ -560,7 +564,6 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
 
                 auto stbl = std::make_shared<StblBox>();
                 {
-                    
                     auto stts = std::make_shared<SttsBox>();
                     stbl->add_box(stts);
                     auto stsc = std::make_shared<StscBox>();
@@ -572,38 +575,37 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
 
                     auto stsd = std::make_shared<StsdBox>();
                     {
-                        AACCodec *aac_codec = ((AACCodec*)audio_codec_.get());
+                        AACCodec *aac_codec = ((AACCodec *)audio_codec_.get());
                         auto audio_specific_config = aac_codec->get_audio_specific_config();
                         auto mp4a = std::make_shared<AudioSampleEntry>(BOX_TYPE_MP4A);
                         mp4a->data_reference_index_ = 1;
                         mp4a->sample_rate_ = (audio_specific_config->sampling_frequency << 16);
-                        mp4a->sample_size_ = 16;//aac 固定位深为16
+                        mp4a->sample_size_ = 16;  // aac 固定位深为16
                         mp4a->channel_count_ = audio_specific_config->channel_configuration;
-                        
+
                         AudioTagHeader header;
                         auto payload = audio_pkt->get_using_data();
-                        int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+                        int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
                         auto esds = std::make_shared<EsdsBox>();
                         mp4a->esds_ = esds;
-                        Mp4ES_Descriptor & es = esds->es_;
+                        Mp4ES_Descriptor &es = esds->es_;
                         es.ES_ID_ = 0x02;
-                        Mp4DecoderConfigDescriptor& desc = es.decConfigDescr_;
+                        Mp4DecoderConfigDescriptor &desc = es.decConfigDescr_;
                         desc.object_type_indication_ = Mp4ObjectTypeAac;
                         desc.stream_type_ = Mp4StreamTypeAudioStream;
 
                         desc.dec_specific_info_ = std::make_shared<Mp4DecoderSpecificInfo>();
-                        desc.dec_specific_info_->asc_ = std::string(payload.data() + header_consumed, payload.size() - header_consumed);
+                        desc.dec_specific_info_->asc_ =
+                            std::string(payload.data() + header_consumed, payload.size() - header_consumed);
 
                         stsd->entries_.push_back(mp4a);
                     }
                     stbl->add_box(stsd);
-                    
                 }
                 minf->add_box(stbl);
             }
             mdia->set_minf(minf);
-        }   
-
+        }
     }
 
     auto mvex = std::make_shared<MvexBox>();
@@ -612,7 +614,7 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
     trex->default_sample_description_index_ = 1;
     mvex->set_trex(trex);
     video_moov_->add_box(mvex);
-    
+
     video_moov_->size();
     n = NetBuffer(init_audio_mp4_seg_->alloc_buffer(video_moov_->size()));
     video_moov_->encode(n);
@@ -627,7 +629,7 @@ bool RtmpToMp4::generate_audio_init_seg(std::shared_ptr<RtmpMessage> audio_pkt) 
 bool RtmpToMp4::process_h265_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
@@ -636,13 +638,14 @@ bool RtmpToMp4::process_h265_packet(std::shared_ptr<RtmpMessage> video_pkt) {
         return false;
     }
 
-    HevcCodec *hevc_codec = ((HevcCodec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    HevcCodec *hevc_codec = ((HevcCodec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析hvcc configuration heade
         HEVCDecoderConfigurationRecord hevc_decoder_configuration_record;
-        int32_t consumed = hevc_decoder_configuration_record.decode((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = hevc_decoder_configuration_record.decode(
+            (uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed);
         if (consumed == 0) {
             return false;
         }
@@ -653,12 +656,12 @@ bool RtmpToMp4::process_h265_packet(std::shared_ptr<RtmpMessage> video_pkt) {
             return false;
         }
         return true;
-    } 
+    }
 
     return true;
 }
 
-int32_t RtmpToMp4::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> & nalus) {
+int32_t RtmpToMp4::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> &nalus) {
     uint8_t *data_start = data;
     while (len > 0) {
         int32_t nalu_len = 0;
@@ -681,7 +684,7 @@ int32_t RtmpToMp4::get_nalus(uint8_t *data, int32_t len, std::list<std::string_v
             return -2;
         }
 
-        nalus.emplace_back(std::string_view((char*)data, nalu_len));
+        nalus.emplace_back(std::string_view((char *)data, nalu_len));
         data += nalu_len;
         len -= nalu_len;
     }
@@ -704,18 +707,19 @@ bool RtmpToMp4::on_audio_packet(std::shared_ptr<RtmpMessage> audio_pkt) {
 bool RtmpToMp4::process_aac_packet(std::shared_ptr<RtmpMessage> audio_pkt) {
     AudioTagHeader header;
     auto payload = audio_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         return false;
     }
-    
-    AACCodec *aac_codec = ((AACCodec*)audio_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+
+    AACCodec *aac_codec = ((AACCodec *)audio_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         audio_ready_ = true;
         audio_header_ = audio_pkt;
         // 解析aac configuration header
         std::shared_ptr<AudioSpecificConfig> audio_config = std::make_shared<AudioSpecificConfig>();
-        int32_t consumed = audio_config->parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = audio_config->parse((uint8_t *)payload.data() + header_consumed,
+                                               payload.size() - header_consumed);
         if (consumed < 0) {
             CORE_ERROR("parse aac audio header failed, ret:{}", consumed);
             return false;
@@ -751,7 +755,7 @@ void RtmpToMp4::reap_audio_seg(int64_t dts) {
     audio_data_mp4_seg_ = std::make_shared<Mp4Segment>();
     std::stringstream ss;
     ss << "audio-" << audio_seq_no_ << ".m4s";
-    std::ofstream of(ss.str(), std::ios::out|std::ios::binary);
+    std::ofstream of(ss.str(), std::ios::out | std::ios::binary);
     StypBox styp;
     styp.major_brand_ = Mp4BoxBrandMSDH;
     styp.minor_version_ = 0;
@@ -789,15 +793,12 @@ void RtmpToMp4::reap_audio_seg(int64_t dts) {
     traf->tfhd_ = tfhd;
 
     auto tfdt = std::make_shared<TfdtBox>();
-    tfdt->base_media_decode_time = 1;//in ms
+    tfdt->base_media_decode_time = 1;  // in ms
     tfdt->version_ = 1;
     traf->tfdt_ = tfdt;
 
     auto trun = std::make_shared<TrunBox>(0);
-    trun->flags_ = TrunFlagsDataOffset | 
-                   TrunFlagsSampleDuration | 
-                   TrunFlagsSampleSize | 
-                   TrunFlagsSampleFlag | 
+    trun->flags_ = TrunFlagsDataOffset | TrunFlagsSampleDuration | TrunFlagsSampleSize | TrunFlagsSampleFlag |
                    TrunFlagsSampleCtsOffset;
     traf->trun_ = trun;
     trun->entries_.reserve(audio_pkts_.size());
@@ -818,10 +819,10 @@ void RtmpToMp4::reap_audio_seg(int64_t dts) {
         } else {
             te.sample_duration_ = (*it_next)->timestamp_ - (*it)->timestamp_;
         }
-        
+
         auto payload = (*it)->get_using_data();
         AudioTagHeader header;
-        int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+        int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
         te.sample_size_ = payload.size() - header_consumed;
         te.sample_composition_time_offset_ = 0;
         if (te.sample_composition_time_offset_ < 0) {
@@ -835,8 +836,8 @@ void RtmpToMp4::reap_audio_seg(int64_t dts) {
     int64_t moof_bytes = moof->size();
     trun->data_offset_ = (int32_t)(moof_bytes + mdat->size());
     // Update the size of sidx.
-    SegmentIndexEntry* e = &sidx->entries[0];
-    e->referenced_size = moof_bytes +  mdat->size() + mdat_bytes;
+    SegmentIndexEntry *e = &sidx->entries[0];
+    e->referenced_size = moof_bytes + mdat->size() + mdat_bytes;
     s = sidx->size();
     n = NetBuffer(audio_data_mp4_seg_->alloc_buffer(s));
     sidx->encode(n);
@@ -845,21 +846,22 @@ void RtmpToMp4::reap_audio_seg(int64_t dts) {
     n = NetBuffer(audio_data_mp4_seg_->alloc_buffer(s));
     moof->encode(n);
 
-    {//写mdat
+    {  // 写mdat
         s = mdat->size();
         n = NetBuffer(audio_data_mp4_seg_->alloc_buffer(s));
         mdat->encode(n);
         for (auto it = audio_pkts_.begin(); it != audio_pkts_.end(); it++) {
             auto payload = (*it)->get_using_data();
             AudioTagHeader header;
-            int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+            int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
             auto frame_bytes = payload.size() - header_consumed;
             n = NetBuffer(audio_data_mp4_seg_->alloc_buffer(frame_bytes));
-            memcpy((char*)n.get_curr_buf().data(), payload.data() + header_consumed, frame_bytes);
+            memcpy((char *)n.get_curr_buf().data(), payload.data() + header_consumed, frame_bytes);
         }
     }
     audio_data_mp4_seg_->set_seqno(audio_seq_no_);
-    audio_data_mp4_seg_->update_timestamp(audio_pkts_[0]->timestamp_, audio_pkts_[audio_pkts_.size()-1]->timestamp_);
+    audio_data_mp4_seg_->update_timestamp(audio_pkts_[0]->timestamp_,
+                                          audio_pkts_[audio_pkts_.size() - 1]->timestamp_);
     audio_data_mp4_seg_->set_filename("audio-" + std::to_string(audio_seq_no_++) + ".m4s");
     auto used_buf = audio_data_mp4_seg_->get_used_buf();
     of.write(used_buf.data(), used_buf.size());
@@ -877,28 +879,31 @@ void RtmpToMp4::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
-        
-        if (mp4_media_source_) {
-            mp4_media_source_->close();
-            mp4_media_source_ = nullptr;
-        }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        auto origin_source = origin_source_.lock();
-        if (rtmp_media_sink_) {
-            rtmp_media_sink_->on_rtmp_message({});
-            rtmp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtmp_media_sink_);
+            if (mp4_media_source_) {
+                mp4_media_source_->close();
+                mp4_media_source_ = nullptr;
             }
-            rtmp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtmp_media_sink_) {
+                rtmp_media_sink_->on_rtmp_message({});
+                rtmp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtmp_media_sink_);
+                }
+                rtmp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/rtmp/rtmp_to_rtsp.cpp
+++ b/live-server/bridge/rtmp/rtmp_to_rtsp.cpp
@@ -1,95 +1,106 @@
+#include "rtmp_to_rtsp.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "spdlog/spdlog.h"
-#include "rtmp_to_rtsp.hpp"
 #include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
-#include "core/rtsp_media_source.hpp"
-#include "core/rtmp_media_sink.hpp"
-
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/sdp/sdp.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
 #include "codec/h264/h264_codec.hpp"
 #include "codec/hevc/hevc_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
 #include "codec/mp3/mp3_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
-#include "codec/aac/adts.hpp"
-#include "base/utils/utils.h"
-
-#include "app/publish_app.h"
 #include "config/app_config.h"
+#include "core/rtmp_media_sink.hpp"
+#include "core/rtsp_media_source.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/sdp/sdp.hpp"
+#include "spdlog/spdlog.h"
+
 
 using namespace mms;
 
-RtmpToRtsp::RtmpToRtsp(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<RtspMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+RtmpToRtsp::RtmpToRtsp(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                       std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                       const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<RtspMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     rtsp_media_source_ = std::static_pointer_cast<RtspMediaSource>(source_);
-    sink_ = std::make_shared<RtmpMediaSink>(worker); 
+    sink_ = std::make_shared<RtmpMediaSink>(worker);
     rtmp_media_sink_ = std::static_pointer_cast<RtmpMediaSink>(sink_);
     CORE_DEBUG("create RtmpToRtsp");
     type_ = "rtmp-to-rtsp";
 }
 
-RtmpToRtsp::~RtmpToRtsp() {
-    CORE_DEBUG("destroy RtmpToRtsp");
-}
+RtmpToRtsp::~RtmpToRtsp() { CORE_DEBUG("destroy RtmpToRtsp"); }
 
 bool RtmpToRtsp::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
-
-            if (rtsp_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                CORE_DEBUG("close RtmpToRtsp because no players for 30s");
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
-
-    rtmp_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        rtsp_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            rtmp_media_sink_->on_rtmp_message([this, self](const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs)->boost::asio::awaitable<bool> {
-                for (auto rtmp_msg : rtmp_msgs) {
-                    if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
-                        if (!co_await this->on_audio_packet(rtmp_msg)) {
-                            co_return false;
-                        }
-                    } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
-                        if (!co_await this->on_video_packet(rtmp_msg)) { 
-                            co_return false;
-                        }
-                    } else {
-                        if (!this->on_metadata(rtmp_msg)) {
-                            co_return false;
-                        }
-                    }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(
+                    std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms() / 2));
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
                 }
-                co_return true;
-            });
-        }
-        co_return;
-    });
+
+                if (rtsp_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    CORE_DEBUG("close RtmpToRtsp because no players for 30s");
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
+
+    rtmp_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            rtsp_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                rtmp_media_sink_->on_rtmp_message(
+                    [this, self](const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs)
+                        -> boost::asio::awaitable<bool> {
+                        for (auto rtmp_msg : rtmp_msgs) {
+                            if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_AUDIO) {
+                                if (!co_await this->on_audio_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else if (rtmp_msg->get_message_type() == RTMP_MESSAGE_TYPE_VIDEO) {
+                                if (!co_await this->on_video_packet(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            } else {
+                                if (!this->on_metadata(rtmp_msg)) {
+                                    co_return false;
+                                }
+                            }
+                        }
+                        co_return true;
+                    });
+            }
+            co_return;
+        });
 
     return true;
 }
@@ -127,7 +138,7 @@ bool RtmpToRtsp::on_metadata(std::shared_ptr<RtmpMessage> metadata_pkt) {
     }
 
     return true;
-} 
+}
 
 boost::asio::awaitable<bool> RtmpToRtsp::on_video_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     if (!video_codec_) {
@@ -140,9 +151,8 @@ boost::asio::awaitable<bool> RtmpToRtsp::on_video_packet(std::shared_ptr<RtmpMes
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         co_return co_await process_h265_packet(video_pkt);
     } else {
-        
     }
-    
+
     co_return true;
 }
 
@@ -160,24 +170,26 @@ boost::asio::awaitable<bool> RtmpToRtsp::on_audio_packet(std::shared_ptr<RtmpMes
 boost::asio::awaitable<bool> RtmpToRtsp::process_h264_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
-    
-    H264Codec *h264_codec = ((H264Codec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+
+    H264Codec *h264_codec = ((H264Codec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // sequence_header = true;
         // 解析avc configuration header
         AVCDecoderConfigurationRecord avc_decoder_configuration_record;
-        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = avc_decoder_configuration_record.parse((uint8_t *)payload.data() + header_consumed,
+                                                                  payload.size() - header_consumed);
         if (consumed < 0) {
             co_return false;
         }
 
-        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(), avc_decoder_configuration_record.get_pps());
+        h264_codec->set_sps_pps(avc_decoder_configuration_record.get_sps(),
+                                avc_decoder_configuration_record.get_pps());
         nalu_length_size_ = avc_decoder_configuration_record.nalu_length_size_minus_one + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
             co_return false;
@@ -188,11 +200,12 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h264_packet(std::shared_ptr<Rtm
         }
 
         co_return true;
-    } 
+    }
 
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         co_return false;
     }
@@ -222,8 +235,10 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h264_packet(std::shared_ptr<Rtm
             h264_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type == H264NaluTypeIDR) {
             if (!has_pps_nalu && !has_sps_nalu) {
-                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(), h264_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(), h264_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(),
+                                                       h264_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(),
+                                                       h264_codec->get_sps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
             }
@@ -240,13 +255,13 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h264_packet(std::shared_ptr<Rtm
         co_return true;
     }
 
-    static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
-    static std::string_view aud_nalu((char*)default_aud_nalu, 2);
+    static uint8_t default_aud_nalu[] = {0x09, 0xf0};
+    static std::string_view aud_nalu((char *)default_aud_nalu, 2);
     if (!has_aud_nalu) {
         nalus.push_front(aud_nalu);
     }
 
-    auto rtp_pkts = video_rtp_packer_->pack(nalus, video_pt_, 0, (pts - first_video_pts_)*90);
+    auto rtp_pkts = video_rtp_packer_->pack(nalus, video_pt_, 0, (pts - first_video_pts_) * 90);
     co_await rtsp_media_source_->on_video_packets(rtp_pkts);
 
     co_return true;
@@ -255,23 +270,26 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h264_packet(std::shared_ptr<Rtm
 boost::asio::awaitable<bool> RtmpToRtsp::process_h265_packet(std::shared_ptr<RtmpMessage> video_pkt) {
     VideoTagHeader header;
     auto payload = video_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
 
-    HevcCodec *hevc_codec = ((HevcCodec*)video_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    HevcCodec *hevc_codec = ((HevcCodec *)video_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         video_ready_ = true;
         video_header_ = video_pkt;
         // 解析avc configuration header
         HEVCDecoderConfigurationRecord hevc_decoder_configuration_record;
-        int32_t consumed = hevc_decoder_configuration_record.decode((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = hevc_decoder_configuration_record.decode(
+            (uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed);
         if (consumed < 0) {
             co_return false;
         }
 
-        hevc_codec->set_sps_pps_vps(hevc_decoder_configuration_record.get_sps(), hevc_decoder_configuration_record.get_pps(), hevc_decoder_configuration_record.get_vps());
+        hevc_codec->set_sps_pps_vps(hevc_decoder_configuration_record.get_sps(),
+                                    hevc_decoder_configuration_record.get_pps(),
+                                    hevc_decoder_configuration_record.get_vps());
         nalu_length_size_ = hevc_decoder_configuration_record.lengthSizeMinusOne + 1;
         if (nalu_length_size_ == 3 || nalu_length_size_ > 4) {
             co_return false;
@@ -282,11 +300,12 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h265_packet(std::shared_ptr<Rtm
         }
 
         co_return true;
-    } 
+    }
 
     // 获取到nalus
     std::list<std::string_view> nalus;
-    auto consumed = get_nalus((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
+    auto consumed =
+        get_nalus((uint8_t *)payload.data() + header_consumed, payload.size() - header_consumed, nalus);
     if (consumed < 0) {
         co_return false;
     }
@@ -319,15 +338,18 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h265_packet(std::shared_ptr<Rtm
 
     if (has_key_nalu) {
         if (!has_pps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(), hevc_codec->get_pps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_pps_nalu().data(),
+                                                         hevc_codec->get_pps_nalu().size()));
         }
 
         if (!has_sps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_sps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
 
         if (!has_vps_nalu) {
-            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(), hevc_codec->get_sps_nalu().size()));
+            nalus.insert(nalus.begin(), std::string_view(hevc_codec->get_vps_nalu().data(),
+                                                         hevc_codec->get_sps_nalu().size()));
         }
     }
 
@@ -337,12 +359,12 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_h265_packet(std::shared_ptr<Rtm
     //     nalus.push_front(aud_nalu);
     // }
 
-    auto rtp_pkts = video_rtp_packer_->pack(nalus, video_pt_, 0, (pts - first_video_pts_)*90);
+    auto rtp_pkts = video_rtp_packer_->pack(nalus, video_pt_, 0, (pts - first_video_pts_) * 90);
     co_await rtsp_media_source_->on_video_packets(rtp_pkts);
     co_return true;
 }
 
-int32_t RtmpToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> & nalus) {
+int32_t RtmpToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_view> &nalus) {
     uint8_t *data_start = data;
     while (len > 0) {
         int32_t nalu_len = 0;
@@ -365,29 +387,29 @@ int32_t RtmpToRtsp::get_nalus(uint8_t *data, int32_t len, std::list<std::string_
             return -2;
         }
 
-        nalus.emplace_back(std::string_view((char*)data, nalu_len));
+        nalus.emplace_back(std::string_view((char *)data, nalu_len));
         data += nalu_len;
         len -= nalu_len;
     }
     return data - data_start;
 }
 
-
 boost::asio::awaitable<bool> RtmpToRtsp::process_aac_packet(std::shared_ptr<RtmpMessage> audio_pkt) {
     AudioTagHeader header;
     auto payload = audio_pkt->get_using_data();
-    int32_t header_consumed = header.decode((uint8_t*)payload.data(), payload.size());
+    int32_t header_consumed = header.decode((uint8_t *)payload.data(), payload.size());
     if (header_consumed < 0) {
         co_return false;
     }
 
-    AACCodec *aac_codec = ((AACCodec*)audio_codec_.get());
-    if (header.is_seq_header()) {// 关键帧索引
+    AACCodec *aac_codec = ((AACCodec *)audio_codec_.get());
+    if (header.is_seq_header()) {  // 关键帧索引
         audio_ready_ = true;
         audio_header_ = audio_pkt;
         // 解析avc configuration heade
         auto audio_config = std::make_shared<AudioSpecificConfig>();
-        int32_t consumed = audio_config->parse((uint8_t*)payload.data() + header_consumed, payload.size() - header_consumed);
+        int32_t consumed = audio_config->parse((uint8_t *)payload.data() + header_consumed,
+                                               payload.size() - header_consumed);
         if (consumed < 0) {
             spdlog::error("parse aac audio header failed, ret:{}", consumed);
             co_return false;
@@ -415,9 +437,9 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_aac_packet(std::shared_ptr<Rtmp
     }
 
     int32_t payload_size = payload.size() - header_consumed;
-    int16_t au_header_bytes = (13 + 3)/8;
-    char *p = (char*)audio_buf_;
-    *(uint16_t*)p = htons(au_header_bytes*8);
+    int16_t au_header_bytes = (13 + 3) / 8;
+    char *p = (char *)audio_buf_;
+    *(uint16_t *)p = htons(au_header_bytes * 8);
     p += 2;
     memset(p, 0, 2);
     BitStream bit_stream(std::string_view(p, au_header_bytes));
@@ -430,7 +452,9 @@ boost::asio::awaitable<bool> RtmpToRtsp::process_aac_packet(std::shared_ptr<Rtmp
     memcpy(p, payload.data() + header_consumed, payload_size);
     p += payload_size;
 
-    auto rtp_pkts = audio_rtp_packer_.pack((char*)audio_buf_, p - (char*)audio_buf_, audio_pt_, 0, ((audio_pkt->timestamp_-first_audio_pts_)*audio_config->sampling_frequency)/1000);
+    auto rtp_pkts = audio_rtp_packer_.pack(
+        (char *)audio_buf_, p - (char *)audio_buf_, audio_pt_, 0,
+        ((audio_pkt->timestamp_ - first_audio_pts_) * audio_config->sampling_frequency) / 1000);
     auto ret = co_await rtsp_media_source_->on_audio_packets(rtp_pkts);
     if (!ret) {
         co_return false;
@@ -448,11 +472,8 @@ a=tool:libavformat 59.34.102
 m=video 0 RTP/AVP 96
 b=AS:1890
 a=rtpmap:96 H264/90000
-a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs; profile-level-id=64001E
-a=control:streamid=0
-m=audio 0 RTP/AVP 97
-b=AS:128
-a=rtpmap:97 MPEG4-GENERIC/48000/2
+a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs;
+profile-level-id=64001E a=control:streamid=0 m=audio 0 RTP/AVP 97 b=AS:128 a=rtpmap:97 MPEG4-GENERIC/48000/2
 a=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=119056E500
 a=control:streamid=1
 */
@@ -463,11 +484,9 @@ t=0 0
 a=tool:mms
 m=video 0 RTP/AVP 96
 a=rtpmap:96 H264/90000
-a=fmtp:96 profile-level-id=64001E; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs; packetization-mode=1
-a=control:streamid=0
-m=audio 0 RTP/AVP 97
-a=rtpmap:97 MPEG4-GENERIC/44100/2
-a=fmtp:97 config=121056E500; indexdeltalength=3; indexlength=3; sizelength=13; mode=AAC-hbr; profile-level-id=1
+a=fmtp:96 profile-level-id=64001E; sprop-parameter-sets=Z2QAHqzZQFAFuwEQAGXTsBMS0AjxYtlg,aOrgjLIs;
+packetization-mode=1 a=control:streamid=0 m=audio 0 RTP/AVP 97 a=rtpmap:97 MPEG4-GENERIC/44100/2 a=fmtp:97
+config=121056E500; indexdeltalength=3; indexlength=3; sizelength=13; mode=AAC-hbr; profile-level-id=1
 a=control:streamid=1
 */
 
@@ -482,8 +501,8 @@ a=fmtp:97 config=1210; indexdeltalength=3; indexlength=3; sizelength=13; mode=AA
 a=control:streamid=0
 m=video 0 RTP/AVP/TCP 96
 a=rtpmap:96 H264/90000
-a=fmtp:96 sprop-parameter-sets=Z0LAHtoCgL/lwFqAgICgAAADACAAAAZR4sXU,aM48gA==; profile-level-id=42001f; level-asymmetry-allowed=1; packetization-mode=1
-a=control:streamid=1
+a=fmtp:96 sprop-parameter-sets=Z0LAHtoCgL/lwFqAgICgAAADACAAAAZR4sXU,aM48gA==; profile-level-id=42001f;
+level-asymmetry-allowed=1; packetization-mode=1 a=control:streamid=1
 */
 bool RtmpToRtsp::generate_sdp() {
     if (has_audio_) {
@@ -502,10 +521,10 @@ bool RtmpToRtsp::generate_sdp() {
 
     sdp_ = std::make_shared<Sdp>();
     sdp_->set_version(0);
-    sdp_->set_origin({"-", 0, 0, "IN", "IP4", "127.0.0.1"}); // o=- get_rand64 1 IN IP4 127.0.0.1
+    sdp_->set_origin({"-", 0, 0, "IN", "IP4", "127.0.0.1"});  // o=- get_rand64 1 IN IP4 127.0.0.1
     auto session_name = domain_name_ + "/" + app_name_ + "/" + stream_name_;
-    sdp_->set_session_name(session_name);                                  //
-    sdp_->set_time({0, 0});                                                // t=0 0
+    sdp_->set_session_name(session_name);  //
+    sdp_->set_time({0, 0});                // t=0 0
     sdp_->set_tool({"mms"});
     if (has_audio_ && audio_codec_) {
         MediaSdp audio_sdp;
@@ -516,24 +535,29 @@ bool RtmpToRtsp::generate_sdp() {
         audio_sdp.add_fmt(audio_pt_);
         audio_sdp.set_control(Control("streamid=1"));
         if (audio_codec_->get_codec_type() == CODEC_AAC) {
-            auto aac_codec = (AACCodec*)audio_codec_.get();
+            auto aac_codec = (AACCodec *)audio_codec_.get();
             auto audio_specific_config = aac_codec->get_audio_specific_config();
             if (!audio_specific_config) {
                 return false;
             }
-            Payload audio_payload(audio_pt_, "MPEG4-GENERIC", audio_specific_config->sampling_frequency, {std::to_string(audio_specific_config->channel_configuration)});
+            Payload audio_payload(audio_pt_, "MPEG4-GENERIC", audio_specific_config->sampling_frequency,
+                                  {std::to_string(audio_specific_config->channel_configuration)});
             Fmtp fmtp;
             /*
             struct AUConfig {
-                uint32_t constant_size;//constant_size和size_length不能同时出现, 一般都是size_length，目前先处理这种情况，constant_size应该是在某种编码模式固定长度的时候用
-                uint16_t size_length = 0;//The number of bits on which the AU-size field is encoded in the AU-header. 如果没有这个字段，则au-headers-length字段也不存在
-                uint16_t index_length = 0;//The number of bits on which the AU-Index is encoded in the first AU-header
-                uint16_t index_delta_length = 0;//The number of bits on which the AU-Index-delta field is encoded in any non-first AU-header.
-                uint16_t cts_delta_length;//The number of bits on which the CTS-delta field is encoded in the AU-header.
-                uint16_t dts_delta_length;//The number of bits on which the DTS-delta field is encoded in the AU-header.
-                uint8_t random_access_indication;//A decimal value of zero or one, indicating whether the RAP-flag is present in the AU-header.
-                uint8_t stream_state_indication;//The number of bits on which the Stream-state field is encoded in the AU-header.
-                uint16_t auxiliary_data_size_length;//The number of bits that is used to encode the auxiliary-data-size field.
+                uint32_t constant_size;//constant_size和size_length不能同时出现,
+            一般都是size_length，目前先处理这种情况，constant_size应该是在某种编码模式固定长度的时候用
+                uint16_t size_length = 0;//The number of bits on which the AU-size field is encoded in the
+            AU-header. 如果没有这个字段，则au-headers-length字段也不存在 uint16_t index_length = 0;//The
+            number of bits on which the AU-Index is encoded in the first AU-header uint16_t index_delta_length
+            = 0;//The number of bits on which the AU-Index-delta field is encoded in any non-first AU-header.
+                uint16_t cts_delta_length;//The number of bits on which the CTS-delta field is encoded in the
+            AU-header. uint16_t dts_delta_length;//The number of bits on which the DTS-delta field is encoded
+            in the AU-header. uint8_t random_access_indication;//A decimal value of zero or one, indicating
+            whether the RAP-flag is present in the AU-header. uint8_t stream_state_indication;//The number of
+            bits on which the Stream-state field is encoded in the AU-header. uint16_t
+            auxiliary_data_size_length;//The number of bits that is used to encode the auxiliary-data-size
+            field.
             };
             */
             fmtp.set_pt(audio_pt_);
@@ -545,7 +569,7 @@ bool RtmpToRtsp::generate_sdp() {
             auto config_size = audio_specific_config->size();
             std::string config;
             config.resize(config_size);
-            audio_specific_config->encode((uint8_t*)config.data(), config_size);
+            audio_specific_config->encode((uint8_t *)config.data(), config_size);
             std::string hex_config;
             Utils::bin_to_hex_str(config, hex_config);
             fmtp.add_param("config", hex_config);
@@ -566,7 +590,7 @@ bool RtmpToRtsp::generate_sdp() {
         video_sdp.set_proto("RTP/AVP");
         video_sdp.set_control(Control("streamid=0"));
         if (video_codec_->get_codec_type() == CODEC_H264) {
-            auto h264_codec = (H264Codec*)video_codec_.get();
+            auto h264_codec = (H264Codec *)video_codec_.get();
             auto sps = h264_codec->get_sps_nalu();
             auto pps = h264_codec->get_pps_nalu();
             std::string sps_base64;
@@ -580,13 +604,13 @@ bool RtmpToRtsp::generate_sdp() {
             fmtp.add_param("packetization-mode", "1");
             // fmtp.add_param("level-asymmetry-allowed", "1");
             // fmtp.add_param("profile-level-id", "42001f");
-            fmtp.add_param("sprop-parameter-sets", sps_base64 + ","+pps_base64);
+            fmtp.add_param("sprop-parameter-sets", sps_base64 + "," + pps_base64);
             video_payload.add_fmtp(fmtp);
 
             video_sdp.add_payload(video_payload);
             sdp_->add_media_sdp(video_sdp);
         } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
-            auto h265_codec = (HevcCodec*)video_codec_.get();
+            auto h265_codec = (HevcCodec *)video_codec_.get();
             auto sps = h265_codec->get_sps_nalu();
             auto pps = h265_codec->get_pps_nalu();
             auto vps = h265_codec->get_vps_nalu();
@@ -628,28 +652,31 @@ void RtmpToRtsp::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (rtsp_media_source_) {
-            rtsp_media_source_->close();
-            rtsp_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtmp_media_sink_) {
-            rtmp_media_sink_->on_rtmp_message({});
-            rtmp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtmp_media_sink_);
+            if (rtsp_media_source_) {
+                rtsp_media_source_->close();
+                rtsp_media_source_ = nullptr;
             }
-            rtmp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtmp_media_sink_) {
+                rtmp_media_sink_->on_rtmp_message({});
+                rtmp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtmp_media_sink_);
+                }
+                rtmp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/rtsp/rtsp_to_flv.cpp
+++ b/live-server/bridge/rtsp/rtsp_to_flv.cpp
@@ -1,130 +1,144 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/redirect_error.hpp>
-#include <boost/asio/detached.hpp>
-
 #include "rtsp_to_flv.hpp"
 
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+
+#include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
 #include "base/wait_group.h"
-
-#include "core/rtp_media_sink.hpp"
-#include "core/flv_media_source.hpp"
-#include "codec/codec.hpp"
 #include "codec/aac/aac_codec.hpp"
+#include "codec/codec.hpp"
 #include "codec/h264/h264_codec.hpp"
-#include "app/publish_app.h"
-#include "config/app_config.h"
-#include "protocol/rtp/h265_rtp_pkt_info.h"
-#include "codec/hevc/hevc_define.hpp"
 #include "codec/hevc/hevc_codec.hpp"
+#include "codec/hevc/hevc_define.hpp"
+#include "config/app_config.h"
+#include "core/flv_media_source.hpp"
+#include "core/rtp_media_sink.hpp"
+#include "protocol/rtp/h265_rtp_pkt_info.h"
+
 
 using namespace mms;
 
-RtspToFlv::RtspToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<FlvMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), app);
+RtspToFlv::RtspToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                     std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                     const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<FlvMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), app);
     flv_media_source_ = std::static_pointer_cast<FlvMediaSource>(source_);
-    sink_ = std::make_shared<RtpMediaSink>(worker); 
+    sink_ = std::make_shared<RtpMediaSink>(worker);
     rtp_media_sink_ = std::static_pointer_cast<RtpMediaSink>(sink_);
-    video_frame_cache_ = std::make_unique<char[]>(1024*1024);
-    audio_frame_cache_ = std::make_unique<char[]>(1024*20);
+    video_frame_cache_ = std::make_unique<char[]>(1024 * 1024);
+    audio_frame_cache_ = std::make_unique<char[]>(1024 * 20);
     type_ = "rtsp-to-flv";
 }
 
-RtspToFlv::~RtspToFlv() {
-}
+RtspToFlv::~RtspToFlv() {}
 
 bool RtspToFlv::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
+
+                if (flv_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
+
+    rtp_media_sink_->set_source_codec_ready_cb(
+        [this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec) -> bool {
+            video_codec_ = video_codec;
+            audio_codec_ = audio_codec;
+            if (video_codec_) {
+                has_video_ = true;
             }
 
-            if (flv_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                break;
+            if (audio_codec_) {
+                if (audio_codec_->get_codec_type() != CODEC_AAC) {
+                    return false;
+                }
+                has_audio_ = true;
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
 
-    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec)->bool {
-        video_codec_ = video_codec;
-        audio_codec_ = audio_codec;
-        if (video_codec_) {
-            has_video_ = true;
-        }
-
-        if (audio_codec_) {
-            if (audio_codec_->get_codec_type() != CODEC_AAC) {
+            if (!generate_metadata()) {
                 return false;
             }
-            has_audio_ = true;
-        }
 
-        if (!generate_metadata()) {
-            return false;
-        }
-
-        if (!flv_media_source_->on_metadata(metadata_pkt_)) {
-            return false;
-        }
-
-        if (!generate_video_header()) {
-            return false;
-        }
-
-        if (!flv_media_source_->on_video_packet(video_header_)) {
-            return false;
-        }
-
-        if (!generate_audio_header()) {
-            return false;
-        }
-
-        if (!flv_media_source_->on_audio_packet(audio_header_)) {
-            return false;
-        }
-
-        return true;
-    });
-
-    rtp_media_sink_->set_video_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_video_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_video_ts_ = pkts[0]->get_timestamp();
+            if (!flv_media_source_->on_metadata(metadata_pkt_)) {
+                return false;
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_video_packet(pkt);
-        }
-        
-        co_return true;
-    });
-
-    rtp_media_sink_->set_audio_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_audio_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+            if (!generate_video_header()) {
+                return false;
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_audio_packet(pkt);
-        }
-        
-        co_return true;
-    });
+            if (!flv_media_source_->on_video_packet(video_header_)) {
+                return false;
+            }
+
+            if (!generate_audio_header()) {
+                return false;
+            }
+
+            if (!flv_media_source_->on_audio_packet(audio_header_)) {
+                return false;
+            }
+
+            return true;
+        });
+
+    rtp_media_sink_->set_video_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_video_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_video_ts_ = pkts[0]->get_timestamp();
+                }
+            }
+
+            for (auto pkt : pkts) {
+                process_video_packet(pkt);
+            }
+
+            co_return true;
+        });
+
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_audio_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+                }
+            }
+
+            for (auto pkt : pkts) {
+                process_audio_packet(pkt);
+            }
+
+            co_return true;
+        });
 
     return true;
 }
@@ -154,7 +168,7 @@ bool RtspToFlv::generate_metadata() {
         "width" : 1280.0
     }
     */
-    Amf0String name1; 
+    Amf0String name1;
     name1.set_value("@setDataFrame");
     Amf0String name2;
     name2.set_value("onMetaData");
@@ -179,7 +193,7 @@ bool RtspToFlv::generate_metadata() {
             metadata_amf0_.set_item_value("stereo", false);
         }
         metadata_amf0_.set_item_value("audiodatarate", (double)audio_codec_->get_data_rate());
-        metadata_amf0_.set_item_value("audiosamplesize", 16.0);//好像aac是固定的16bit
+        metadata_amf0_.set_item_value("audiosamplesize", 16.0);  // 好像aac是固定的16bit
     }
     metadata_amf0_.set_item_value("duration", 0.0);
     metadata_amf0_.set_item_value("encoder", "mms");
@@ -217,14 +231,14 @@ bool RtspToFlv::generate_metadata() {
     metadata_pkt_->tag_header.data_size = total_bytes;
 
     auto unuse_data = metadata_pkt_->get_unuse_data();
-    uint8_t* payload = (uint8_t*)unuse_data.data() + FLV_TAG_HEADER_BYTES;
+    uint8_t *payload = (uint8_t *)unuse_data.data() + FLV_TAG_HEADER_BYTES;
     size_t payload_bytes = unuse_data.size() - FLV_TAG_HEADER_BYTES;
     int32_t consumed1 = name1.encode(payload, payload_bytes);
     int32_t consumed2 = name2.encode(payload + consumed1, payload_bytes - consumed1);
     metadata_amf0_.encode(payload + consumed1 + consumed2, payload_bytes - consumed1 - consumed2);
 
     auto script_data = std::make_unique<SCRIPTDATA>();
-    script_data->payload = std::string_view((char*)payload, total_bytes);
+    script_data->payload = std::string_view((char *)payload, total_bytes);
     metadata_pkt_->tag_data = std::move(script_data);
     metadata_pkt_->encode();
     return true;
@@ -233,7 +247,7 @@ bool RtspToFlv::generate_metadata() {
 bool RtspToFlv::generate_video_header() {
     if (video_codec_->get_codec_type() == CODEC_H264) {
         auto h264_codec = std::static_pointer_cast<H264Codec>(video_codec_);
-        AVCDecoderConfigurationRecord & decode_configuration_record = h264_codec->get_avc_configuration();
+        AVCDecoderConfigurationRecord &decode_configuration_record = h264_codec->get_avc_configuration();
         auto payload_size = decode_configuration_record.size();
         // 5 video tag header
         video_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + payload_size);
@@ -246,11 +260,11 @@ bool RtspToFlv::generate_video_header() {
         video_data->header.codec_id = VideoTagHeader::AVC;
         video_data->header.avc_packet_type = VideoTagHeader::AVCSequenceHeader;
         video_data->header.composition_time = 0;
-        
+
         video_header_->tag_header.data_size = 5 + payload_size;
         auto payload = video_header_->get_unuse_data();
         payload.remove_prefix(FLV_TAG_HEADER_BYTES + 5);
-        auto ret = decode_configuration_record.encode((uint8_t*)payload.data(), payload.size());
+        auto ret = decode_configuration_record.encode((uint8_t *)payload.data(), payload.size());
         if (ret < 0) {
         } else {
         }
@@ -268,9 +282,10 @@ bool RtspToFlv::generate_video_header() {
         return true;
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         auto hevc_codec = std::static_pointer_cast<HevcCodec>(video_codec_);
-        auto & decode_configuration_record = hevc_codec->get_hevc_configuration();
+        auto &decode_configuration_record = hevc_codec->get_hevc_configuration();
         auto payload_size = decode_configuration_record.size();
-        video_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + payload_size);//5字节是video tag header的大小
+        video_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 +
+                                                 payload_size);  // 5字节是video tag header的大小
         // rtmp头
         video_header_->tag_header.stream_id = 0;
         video_header_->tag_header.tag_type = FlvTagHeader::VideoTag;
@@ -279,7 +294,7 @@ bool RtspToFlv::generate_video_header() {
         auto video_data = std::make_unique<VIDEODATA>();
         auto payload = video_header_->get_unuse_data();
         payload.remove_prefix(FLV_TAG_HEADER_BYTES + 5);
-        auto ret = decode_configuration_record.encode((uint8_t*)payload.data(), payload.size());
+        auto ret = decode_configuration_record.encode((uint8_t *)payload.data(), payload.size());
         if (ret < 0) {
         } else {
         }
@@ -295,7 +310,7 @@ bool RtspToFlv::generate_video_header() {
         video_header_->encode();
         return true;
     }
-    
+
     return false;
 }
 
@@ -319,12 +334,14 @@ bool RtspToFlv::generate_audio_header() {
         } else {
             audio_data->header.sound_rate = AudioTagHeader::KHZ_44;
         }
-        
+
         audio_data->header.sound_size = AudioTagHeader::Sample_16bit;
         audio_data->header.aac_packet_type = AudioTagHeader::AACSequenceHeader;
 
         auto payload_size = audio_config->size();
-        audio_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 + payload_size);//11字节flv tag头+2字节aac头+audio_specific_config字节数
+        audio_header_ =
+            std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 +
+                                     payload_size);  // 11字节flv tag头+2字节aac头+audio_specific_config字节数
         audio_header_->tag_header.tag_type = FlvTagHeader::AudioTag;
         audio_header_->tag_header.data_size = 2 + payload_size;
         audio_header_->tag_header.stream_id = 0;
@@ -332,7 +349,7 @@ bool RtspToFlv::generate_audio_header() {
 
         auto payload = audio_header_->get_unuse_data();
         payload.remove_prefix(FLV_TAG_HEADER_BYTES + 2);
-        auto ret = audio_config->encode((uint8_t*)payload.data(), payload.size());
+        auto ret = audio_config->encode((uint8_t *)payload.data(), payload.size());
         if (ret < 0) {
             return false;
         }
@@ -341,8 +358,8 @@ bool RtspToFlv::generate_audio_header() {
         audio_header_->tag_data = std::move(audio_data);
         audio_header_->encode();
         return true;
-    } 
-    
+    }
+
     return false;
 }
 
@@ -352,42 +369,44 @@ void RtspToFlv::process_video_packet(std::shared_ptr<RtpPacket> pkt) {
     } else if (video_codec_ && video_codec_->get_codec_type() == CODEC_HEVC) {
         process_h265_packet(pkt);
     }
-} 
+}
 
 void RtspToFlv::process_h264_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h264_nalu = rtp_h264_depacketizer_.on_packet(pkt);
     if (h264_nalu) {
         uint32_t this_timestamp = h264_nalu->get_timestamp();
-        auto flv_tag = generate_h264_flv_tag((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        auto flv_tag = generate_h264_flv_tag((this_timestamp - first_rtp_video_ts_) / 90,
+                                             h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
         if (flv_tag) {
             flv_media_source_->on_video_packet(flv_tag);
         }
     }
 }
 
-std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp,
+                                                         std::shared_ptr<RtpH264NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     int32_t total_payload_bytes = 0;
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
 
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
                     is_key = true;
                 }
-                
+
                 uint32_t s = htonl(nalu_size);
                 memcpy(buf, &s, 4);
                 buf += 4;
@@ -398,23 +417,25 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                 data += 2 + nalu_size;
             }
 
-            if (pkt->get_header().marker == 1) {//最后一个
+            if (pkt->get_header().marker == 1) {  // 最后一个
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.timestamp = timestamp;
                 auto video_data = std::make_unique<VIDEODATA>();
-                
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 if (is_key) {
                     video_dts_ = timestamp;
-                    video_data->header.composition_time = 0;//rtp默认不支持b帧先
+                    video_data->header.composition_time = 0;  // rtp默认不支持b帧先
                 } else {
-                    video_dts_ += 1000/video_fps_;
+                    video_dts_ += 1000 / video_fps_;
                     video_data->header.composition_time = timestamp - video_dts_;
                 }
                 video_data->payload = std::string_view(video_frame_cache_.get(), total_payload_bytes);
@@ -432,7 +453,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                 is_key = true;
             }
 
-            uint32_t s = htonl(pkt->get_payload().size() );
+            uint32_t s = htonl(pkt->get_payload().size());
             memcpy(buf, &s, 4);
             buf += 4;
             memcpy(buf, pkt->get_payload().data(), pkt->get_payload().size());
@@ -440,21 +461,23 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
 
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.timestamp = timestamp;
 
                 auto video_data = std::make_unique<VIDEODATA>();
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 if (is_key) {
                     video_dts_ = timestamp;
-                    video_data->header.composition_time = 0;//rtp默认不支持b帧先
+                    video_data->header.composition_time = 0;  // rtp默认不支持b帧先
                 } else {
-                    video_dts_ += 1000/video_fps_;
+                    video_dts_ += 1000 / video_fps_;
                     video_data->header.composition_time = timestamp - video_dts_;
                 }
                 video_data->payload = std::string_view(video_frame_cache_.get(), total_payload_bytes);
@@ -468,7 +491,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
             }
         } else if (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
             if (pkt_info.is_start_fu()) {
                 do {
@@ -478,8 +501,8 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                         }
 
                         nalu_size += pkt->get_payload().size() - 1;
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
-                        uint8_t nalu_type = (pkt_buf[0]&0xe0)|(pkt_buf[1]&0x1F);
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
+                        uint8_t nalu_type = (pkt_buf[0] & 0xe0) | (pkt_buf[1] & 0x1F);
                         memcpy(buf, &nalu_type, 1);
                         memcpy(buf + 1, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 1;
@@ -488,7 +511,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                         memcpy(buf, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 2;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         break;
@@ -501,27 +524,29 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.timestamp = timestamp;
 
                 auto video_data = std::make_unique<VIDEODATA>();
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 if (is_key) {
                     video_dts_ = timestamp;
-                    video_data->header.composition_time = 0;//rtp默认不支持b帧先
+                    video_data->header.composition_time = 0;  // rtp默认不支持b帧先
                 } else {
-                    video_dts_ += 1000/video_fps_;
+                    video_dts_ += 1000 / video_fps_;
                     video_data->header.composition_time = timestamp - video_dts_;
                 }
-                video_data->payload = std::string_view((char*)video_frame_cache_.get(), total_payload_bytes);
+                video_data->payload = std::string_view((char *)video_frame_cache_.get(), total_payload_bytes);
 
                 video_flv_tag->tag_data = std::move(video_data);
 
@@ -531,34 +556,35 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h264_flv_tag(uint32_t timestamp, std
                 }
                 return video_flv_tag;
             }
-        } 
+        }
     }
     return nullptr;
 }
 
 void RtspToFlv::process_h265_packet(std::shared_ptr<RtpPacket> pkt) {
-    
     auto h265_nalu = rtp_h265_depacketizer_.on_packet(pkt);
     if (h265_nalu) {
         uint32_t this_timestamp = h265_nalu->get_timestamp();
-        auto flv_tag = generate_h265_flv_tag((this_timestamp - first_rtp_video_ts_)/90, h265_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        auto flv_tag = generate_h265_flv_tag((this_timestamp - first_rtp_video_ts_) / 90,
+                                             h265_nalu);  // todo 除90这个要根据sdp来计算，目前固定
         if (flv_tag) {
             flv_media_source_->on_video_packet(flv_tag);
         }
     }
 }
 
-std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std::shared_ptr<RtpH265NALU> & nalu) {
+std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp,
+                                                         std::shared_ptr<RtpH265NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     int32_t total_payload_bytes = 0;
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
 
         H265RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_single_nalu()) {
             if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP && pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
                 is_key = true;
@@ -572,7 +598,8 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
 
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 8 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 8 + total_payload_bytes);
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.timestamp = timestamp;
@@ -582,13 +609,14 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
                 video_data->header.fourcc = VideoTagHeader::HEVC_FOURCC;
                 video_data->header.codec_id = VideoTagHeader::HEVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.ext_packet_type = VideoTagHeader::PacketTypeCodedFrames;
                 if (is_key) {
                     video_dts_ = timestamp;
-                    video_data->header.composition_time = 0;//rtp默认不支持b帧先
+                    video_data->header.composition_time = 0;  // rtp默认不支持b帧先
                 } else {
-                    video_dts_ += 1000/video_fps_;
+                    video_dts_ += 1000 / video_fps_;
                     video_data->header.composition_time = timestamp - video_dts_;
                 }
                 video_data->payload = std::string_view(video_frame_cache_.get(), total_payload_bytes);
@@ -602,22 +630,23 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
             }
         } else if (pkt_info.is_fu()) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
             if (pkt_info.is_start_fu()) {
                 do {
                     if (pkt_info.is_start_fu()) {
-                        if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP && pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
+                        if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP &&
+                            pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
                             is_key = true;
                         }
 
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
                         uint8_t p0 = *pkt_buf;
                         uint8_t p1 = *(pkt_buf + 1);
-                        uint8_t fu_header = pkt_buf[2]; // FU header
-                        uint8_t fu_type = fu_header & 0x3F; // 提取低6位FuType
+                        uint8_t fu_header = pkt_buf[2];      // FU header
+                        uint8_t fu_type = fu_header & 0x3F;  // 提取低6位FuType
 
-                        buf[0] = (p0 & 0x81) | (fu_type << 1); // 假设Type占6位，调整掩码和移位
+                        buf[0] = (p0 & 0x81) | (fu_type << 1);  // 假设Type占6位，调整掩码和移位
                         buf[1] = p1;
                         memcpy(buf + 2, pkt->get_payload().data() + 3, pkt->get_payload().size() - 3);
                         buf += pkt->get_payload().size() - 1;
@@ -627,7 +656,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
                         buf += pkt->get_payload().size() - 3;
                         nalu_size += pkt->get_payload().size() - 3;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         break;
@@ -640,10 +669,11 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
                     }
                 } while (pkt_info.is_fu() && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 8 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 8 + total_payload_bytes);
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.timestamp = timestamp;
@@ -653,13 +683,14 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
                 video_data->header.fourcc = VideoTagHeader::HEVC_FOURCC;
                 video_data->header.codec_id = VideoTagHeader::HEVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.ext_packet_type = VideoTagHeader::PacketTypeCodedFrames;
                 if (is_key) {
                     video_dts_ = timestamp;
-                    video_data->header.composition_time = 0;//rtp默认不支持b帧先
+                    video_data->header.composition_time = 0;  // rtp默认不支持b帧先
                 } else {
-                    video_dts_ += 1000/video_fps_;
+                    video_dts_ += 1000 / video_fps_;
                     video_data->header.composition_time = timestamp - video_dts_;
                 }
                 video_data->payload = std::string_view(video_frame_cache_.get(), total_payload_bytes);
@@ -670,16 +701,16 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_h265_flv_tag(uint32_t timestamp, std
                 if (ret < 0) {
                     spdlog::error("encode flv video tag failed, code:{}", ret);
                 } else {
-                   
                 }
                 return video_flv_tag;
             }
-        } 
+        }
     }
     return nullptr;
 }
 
-std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp, std::shared_ptr<RtpAACNALU> & nalu) {
+std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp,
+                                                        std::shared_ptr<RtpAACNALU> &nalu) {
     /*
         2.4.  Fragmentation of Access Units
 
@@ -693,37 +724,38 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp, std:
         packets MUST NOT contain fragments of multiple Access Units.
     */
     char *buf = audio_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     std::shared_ptr<AACCodec> aac_codec = std::static_pointer_cast<AACCodec>(audio_codec_);
     auto au_config = aac_codec->get_au_config();
     if (!au_config) {
         return nullptr;
     }
 
-    int16_t au_per_header_bytes = (au_config->size_length + au_config->index_length + 7)/8;
-    // spdlog::info("au_config->size_length:{}, au_config->index_length:{}", au_config->size_length, au_config->index_length);
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    int16_t au_per_header_bytes = (au_config->size_length + au_config->index_length + 7) / 8;
+    // spdlog::info("au_config->size_length:{}, au_config->index_length:{}", au_config->size_length,
+    // au_config->index_length);
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
-        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
+        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
         int32_t left_bytes = pkt->get_payload().size();
         const uint8_t *au_section_buf;
-        if (au_config->size_length != 0) {//有sizelength参数
-            uint16_t au_header_bits = ntohs(*(uint16_t*)pkt_buf);
-            if (au_header_bits%8 != 0) {
+        if (au_config->size_length != 0) {  // 有sizelength参数
+            uint16_t au_header_bits = ntohs(*(uint16_t *)pkt_buf);
+            if (au_header_bits % 8 != 0) {
                 return nullptr;
             }
             size_t au_header_bytes_total = au_header_bits / 8;
-            int16_t au_header_count = au_header_bytes_total/au_per_header_bytes;
+            int16_t au_header_count = au_header_bytes_total / au_per_header_bytes;
 
             // 检查头部长度的完整性
             if (size_t(au_header_count * au_per_header_bytes) != au_header_bytes_total) {
                 return nullptr;
             }
-            
-            BitStream bit_stream(std::string_view((char*)pkt_buf + 2, au_header_bytes_total));
+
+            BitStream bit_stream(std::string_view((char *)pkt_buf + 2, au_header_bytes_total));
             au_section_buf = pkt_buf + 2 + au_header_bytes_total;
             left_bytes -= 2 + au_header_bytes_total;
-            for(auto i = 0; i < au_header_count; i++) {
+            for (auto i = 0; i < au_header_count; i++) {
                 uint16_t au_size = 0;
                 if (!bit_stream.read_u(au_config->size_length, au_size)) {
                     return nullptr;
@@ -737,7 +769,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp, std:
                 if (!bit_stream.read_u(au_config->index_length, au_index)) {
                     return nullptr;
                 }
-                
+
                 int32_t copy_bytes = au_size;
                 if (copy_bytes >= left_bytes) {
                     copy_bytes = left_bytes;
@@ -749,7 +781,8 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp, std:
 
             if (pkt->get_header().marker == 1) {
                 int32_t total_payload_bytes = buf - audio_frame_cache_.get();
-                std::shared_ptr<FlvTag> audio_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 + total_payload_bytes);
+                std::shared_ptr<FlvTag> audio_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 + total_payload_bytes);
                 audio_flv_tag->tag_header.tag_type = FlvTagHeader::AudioTag;
                 audio_flv_tag->tag_header.data_size = total_payload_bytes + 2;
                 audio_flv_tag->tag_header.stream_id = 0;
@@ -774,7 +807,7 @@ std::shared_ptr<FlvTag> RtspToFlv::generate_aac_flv_tag(uint32_t timestamp, std:
                 audio_data->header.sound_size = AudioTagHeader::Sample_16bit;
                 audio_data->header.aac_packet_type = AudioTagHeader::AACRaw;
 
-                audio_data->payload = std::string_view((char*)audio_frame_cache_.get(), total_payload_bytes);
+                audio_data->payload = std::string_view((char *)audio_frame_cache_.get(), total_payload_bytes);
                 audio_flv_tag->tag_data = std::move(audio_data);
 
                 auto ret = audio_flv_tag->encode();
@@ -804,7 +837,9 @@ void RtspToFlv::process_aac_packet(std::shared_ptr<RtpPacket> pkt) {
             return;
         }
 
-        auto flv_tag = generate_aac_flv_tag(((this_timestamp - first_rtp_audio_ts_)*1000)/audio_config->sampling_frequency, aac_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        auto flv_tag = generate_aac_flv_tag(
+            ((this_timestamp - first_rtp_audio_ts_) * 1000) / audio_config->sampling_frequency,
+            aac_nalu);  // todo 除90这个要根据sdp来计算，目前固定
         if (flv_tag) {
             flv_media_source_->on_audio_packet(flv_tag);
         }
@@ -817,31 +852,34 @@ void RtspToFlv::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (flv_media_source_) {
-            flv_media_source_->close();
-            flv_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtp_media_sink_) {
-            rtp_media_sink_->set_video_pkts_cb({});
-            rtp_media_sink_->set_audio_pkts_cb({});
-            rtp_media_sink_->set_source_codec_ready_cb({});
-            rtp_media_sink_->close();
-            
-            if (origin_source) {
-                origin_source->remove_media_sink(rtp_media_sink_);
+            if (flv_media_source_) {
+                flv_media_source_->close();
+                flv_media_source_ = nullptr;
             }
-            rtp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtp_media_sink_) {
+                rtp_media_sink_->set_video_pkts_cb({});
+                rtp_media_sink_->set_audio_pkts_cb({});
+                rtp_media_sink_->set_source_codec_ready_cb({});
+                rtp_media_sink_->close();
+
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtp_media_sink_);
+                }
+                rtp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/rtsp/rtsp_to_ts.cpp
+++ b/live-server/bridge/rtsp/rtsp_to_ts.cpp
@@ -3,157 +3,166 @@
  * @Date: 2023-11-09 20:49:39
  * @LastEditTime: 2023-12-30 10:55:35
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\rtsp_to_ts.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "rtsp_to_ts.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "spdlog/spdlog.h"
-#include "rtsp_to_ts.hpp"
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/ts/ts_pat_pmt.hpp"
-#include "protocol/ts/ts_header.hpp"
-#include "protocol/ts/ts_segment.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-
+#include "app/publish_app.h"
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/aac_encoder.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
+#include "codec/av1/av1_codec.hpp"
 #include "codec/h264/h264_codec.hpp"
 #include "codec/hevc/hevc_codec.hpp"
-#include "codec/av1/av1_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
-#include "codec/aac/adts.hpp"
 #include "codec/hevc/hevc_define.hpp"
-
 #include "codec/opus/opus_codec.hpp"
-#include "codec/aac/aac_encoder.hpp"
-#include "protocol/rtp/h265_rtp_pkt_info.h"
-#include "codec/hevc/hevc_define.hpp"
-
-#include "core/rtp_media_sink.hpp"
-#include "base/utils/utils.h"
-#include "app/publish_app.h"
 #include "config/app_config.h"
-
+#include "core/rtp_media_sink.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/rtp/h265_rtp_pkt_info.h"
+#include "protocol/ts/ts_header.hpp"
+#include "protocol/ts/ts_pat_pmt.hpp"
+#include "protocol/ts/ts_segment.hpp"
+#include "spdlog/spdlog.h"
 
 using namespace mms;
-RtspToTs::RtspToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    sink_ = std::make_shared<RtpMediaSink>(worker); 
+RtspToTs::RtspToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                   std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                   const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    sink_ = std::make_shared<RtpMediaSink>(worker);
     rtp_media_sink_ = std::static_pointer_cast<RtpMediaSink>(sink_);
-    source_ = std::make_shared<TsMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<TsMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     ts_media_source_ = std::static_pointer_cast<TsMediaSource>(source_);
     video_pes_segs_.reserve(1024);
 
-    video_frame_cache_ = std::make_unique<char[]>(1024*1024);
-    audio_frame_cache_ = std::make_unique<char[]>(1024*20);
+    video_frame_cache_ = std::make_unique<char[]>(1024 * 1024);
+    audio_frame_cache_ = std::make_unique<char[]>(1024 * 20);
     spdlog::info("create rtsp to ts");
     type_ = "rtsp-to-ts";
 }
 
-RtspToTs::~RtspToTs() {
-
-}
+RtspToTs::~RtspToTs() {}
 
 bool RtspToTs::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
+
+                if (ts_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    spdlog::debug("close RtspToTs because no players for 30s");
+                    break;
+                }
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
+
+    rtp_media_sink_->set_source_codec_ready_cb(
+        [this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec) -> bool {
+            video_codec_ = video_codec;
+            audio_codec_ = audio_codec;
+
+            if (video_codec_) {
+                has_video_ = true;
+                if (video_codec_->get_codec_type() == CODEC_H264) {
+                    video_pid_ = TS_VIDEO_AVC_PID;
+                    video_type_ = TsStreamVideoH264;
+                    continuity_counter_[video_pid_] = 0;
+                } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
+                    video_pid_ = TS_VIDEO_HEVC_PID;
+                    video_type_ = TsStreamVideoH265;
+                    continuity_counter_[video_pid_] = 0;
+                } else {
+                    return false;
+                }
             }
 
-            if (ts_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                spdlog::debug("close RtspToTs because no players for 30s");
-                break;
+            if (audio_codec_) {
+                has_audio_ = true;
+                if (audio_codec_->get_codec_type() == CODEC_AAC) {
+                    audio_pid_ = TS_AUDIO_AAC_PID;
+                    audio_type_ = TsStreamAudioAAC;
+                    continuity_counter_[audio_pid_] = 0;
+                    adts_headers_.reserve(200);
+                } else if (audio_codec_->get_codec_type() == CODEC_MP3) {
+                    audio_pid_ = TS_AUDIO_MP3_PID;
+                    audio_type_ = TsStreamAudioMp3;
+                    continuity_counter_[audio_pid_] = 0;
+                } else {
+                    return false;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
 
-    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec)->bool {
-        video_codec_ = video_codec;
-        audio_codec_ = audio_codec;
-
-        if (video_codec_) {
-            has_video_ = true;
-            if (video_codec_->get_codec_type() == CODEC_H264) {
-                video_pid_ = TS_VIDEO_AVC_PID;
-                video_type_ = TsStreamVideoH264;
-                continuity_counter_[video_pid_] = 0;
-            } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
-                video_pid_ = TS_VIDEO_HEVC_PID;
-                video_type_ = TsStreamVideoH265;
-                continuity_counter_[video_pid_] = 0;
-            } else {
-                return false;
+            if (has_video_) {
+                PCR_PID = video_pid_;
+            } else if (has_audio_) {
+                PCR_PID = audio_pid_;
             }
-        }
 
-        if (audio_codec_) {
-            has_audio_ = true;
-            if (audio_codec_->get_codec_type() == CODEC_AAC) {
-                audio_pid_ = TS_AUDIO_AAC_PID;
-                audio_type_ = TsStreamAudioAAC;
-                continuity_counter_[audio_pid_] = 0;
-                adts_headers_.reserve(200);
-            } else if (audio_codec_->get_codec_type() == CODEC_MP3) {
-                audio_pid_ = TS_AUDIO_MP3_PID;
-                audio_type_ = TsStreamAudioMp3;
-                continuity_counter_[audio_pid_] = 0;
-            } else {
-                return false;
+            return true;
+        });
+
+    rtp_media_sink_->set_video_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_video_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_video_ts_ = pkts[0]->get_timestamp();
+                }
             }
-        }
 
-        if (has_video_) {
-            PCR_PID = video_pid_; 
-        } else if (has_audio_) {
-            PCR_PID = audio_pid_;
-        }
-
-        return true;
-    });
-
-    rtp_media_sink_->set_video_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_video_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_video_ts_ = pkts[0]->get_timestamp();
+            for (auto pkt : pkts) {
+                process_video_packet(pkt);
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_video_packet(pkt);
-        }
-        
-        co_return true;
-    });
+            co_return true;
+        });
 
-    rtp_media_sink_->set_audio_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_audio_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_audio_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+                }
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_audio_packet(pkt, pkt->get_timestamp());
-        }
-        
-        co_return true;
-    });
+            for (auto pkt : pkts) {
+                process_audio_packet(pkt, pkt->get_timestamp());
+            }
+
+            co_return true;
+        });
     return true;
 }
 
@@ -166,37 +175,38 @@ void RtspToTs::process_video_packet(std::shared_ptr<RtpPacket> pkt) {
         process_h264_packet(pkt);
     } else if (video_codec_->get_codec_type() == CODEC_HEVC) {
         process_h265_packet(pkt);
-    } 
-} 
+    }
+}
 
 void RtspToTs::process_h264_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h264_nalu = rtp_h264_depacketizer_.on_packet(pkt);
     if (h264_nalu) {
         int64_t this_timestamp = h264_nalu->get_timestamp();
-        generate_h264_ts((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        generate_h264_ts((this_timestamp - first_rtp_video_ts_) / 90,
+                         h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
     }
 }
 
-void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
 
     std::string_view sps;
     std::string_view pps;
     std::list<std::string_view> nalus;
 
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
@@ -206,19 +216,19 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
                 } else if (nalu_type == H264NaluTypePPS) {
                     pps = std::string_view(buf + 4, nalu_size);
                 }
-                
+
                 uint32_t s = htonl(nalu_size);
                 memcpy(buf, &s, 4);
                 buf += 4;
                 memcpy(buf, data + 2, nalu_size);
-                nalus.emplace_back(std::string_view((char*)data+2, nalu_size));
+                nalus.emplace_back(std::string_view((char *)data + 2, nalu_size));
                 buf += nalu_size;
 
                 pos += 2 + nalu_size;
                 data += 2 + nalu_size;
             }
 
-            if (pkt->get_header().marker == 1) {//最后一个
+            if (pkt->get_header().marker == 1) {  // 最后一个
                 break;
             }
         } else if (pkt_info.is_single_nalu()) {
@@ -234,17 +244,18 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
             memcpy(buf, &s, 4);
             buf += 4;
             memcpy(buf, pkt->get_payload().data(), pkt->get_payload().size());
-            nalus.emplace_back(std::string_view((char*)pkt->get_payload().data(), pkt->get_payload().size()));
+            nalus.emplace_back(
+                std::string_view((char *)pkt->get_payload().data(), pkt->get_payload().size()));
             buf += pkt->get_payload().size();
 
             if (pkt->get_header().marker == 1) {
                 break;
-            } 
+            }
         } else if (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
-            char * buf_data_start = buf;
+            char *buf_data_start = buf;
             if (pkt_info.is_start_fu()) {
                 do {
                     if (pkt_info.is_start_fu()) {
@@ -253,8 +264,8 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
                         }
 
                         nalu_size += pkt->get_payload().size() - 1;
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
-                        uint8_t nalu_type = (pkt_buf[0]&0xe0)|(pkt_buf[1]&0x1F);
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
+                        uint8_t nalu_type = (pkt_buf[0] & 0xe0) | (pkt_buf[1] & 0x1F);
                         memcpy(buf, &nalu_type, 1);
                         memcpy(buf + 1, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 1;
@@ -263,7 +274,7 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
                         memcpy(buf, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 2;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         if (pkt_info.get_nalu_type() == H264NaluTypeSPS) {
@@ -283,25 +294,25 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 break;
             } else {
                 spdlog::error("H264_RTP_PAYLOAD_FU_A nalu not marker");
             }
-        } 
+        }
     }
 
     if (sps.size() > 0) {
         if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
-            H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+            H264Codec *h264_codec = (H264Codec *)video_codec_.get();
             h264_codec->set_sps(std::string(sps.data(), sps.size()));
         }
     }
 
     if (pps.size() > 0) {
         if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
-            H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+            H264Codec *h264_codec = (H264Codec *)video_codec_.get();
             h264_codec->set_pps(std::string(pps.data(), pps.size()));
         }
     }
@@ -313,7 +324,7 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
         wait_first_key_frame_ = false;
     }
 
-    if (!curr_seg_ && !is_key) {//片段开始的帧，必须是关键帧
+    if (!curr_seg_ && !is_key) {  // 片段开始的帧，必须是关键帧
         return;
     }
 
@@ -332,16 +343,16 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
         create_pmt(pmt_seg);
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     // 判断sps,pps,aud等
     bool has_aud_nalu = false;
     bool has_sps_nalu = false;
     bool has_pps_nalu = false;
 
-    H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+    H264Codec *h264_codec = (H264Codec *)video_codec_.get();
     for (auto it = nalus.begin(); it != nalus.end(); it++) {
         H264NaluType nalu_type = H264NaluType((*it->data()) & 0x1f);
         if (nalu_type == H264NaluTypeAccessUnitDelimiter) {
@@ -354,29 +365,31 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
             h264_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type == H264NaluTypeIDR) {
             if (!has_pps_nalu && !has_sps_nalu) {
-                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(), h264_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(), h264_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(),
+                                                       h264_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(),
+                                                       h264_codec->get_sps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
             }
         }
     }
 
-    static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
-    static std::string_view aud_nalu((char*)default_aud_nalu, 2);
+    static uint8_t default_aud_nalu[] = {0x09, 0xf0};
+    static std::string_view aud_nalu((char *)default_aud_nalu, 2);
     if (!has_aud_nalu) {
         nalus.push_front(aud_nalu);
     }
     // 计算payload长度(第一个nalu头部4个字节，后面的头部只需要3字节)
-    int32_t payload_size = nalus.size()*3 + 1;//头部的总字节数
-    for (auto & nalu : nalus) {
+    int32_t payload_size = nalus.size() * 3 + 1;  // 头部的总字节数
+    for (auto &nalu : nalus) {
         payload_size += nalu.size();
     }
 
     // 添加上pes header
     // uint8_t *pes = video_pes_.get();
     char *pes = video_pes_header_;
-    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};//固定3字节头,跟annexb没什么关系
+    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};  // 固定3字节头,跟annexb没什么关系
     memcpy(pes, pes_start_prefix, 3);
     pes += 3;
     // stream_id
@@ -384,40 +397,40 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
     // PES_packet_length
     uint8_t PTS_DTS_flags = 0x03;
     // if (header.composition_time == 0) {//dts = pts时，只需要dts
-        PTS_DTS_flags = 0x02;
+    PTS_DTS_flags = 0x02;
     // }
 
-    //PES_header_data_length
+    // PES_header_data_length
     uint8_t PES_header_data_length = 0;
     if (PTS_DTS_flags == 0x02) {
-        PES_header_data_length = 5;//DTS 5字节
+        PES_header_data_length = 5;  // DTS 5字节
     } else if (PTS_DTS_flags == 0x03) {
-        PES_header_data_length = 10;//PTS 5字节
+        PES_header_data_length = 10;  // PTS 5字节
     }
 
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    if (PTS_DTS_flags & 0x02) {// 填充pts
+    if (PTS_DTS_flags & 0x02) {  // 填充pts
         // uint64_t pts = (video_pkt->timestamp_ + header.composition_time)*90;
-        uint64_t pts = timestamp*90;
+        uint64_t pts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x02 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -426,13 +439,13 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((pts)&0x7fff) << 1) | 1);
+        val = int32_t((((pts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
 
-    if (PTS_DTS_flags & 0x01) {// 填充dts
-        uint64_t dts = timestamp*90;
+    if (PTS_DTS_flags & 0x01) {  // 填充dts
+        uint64_t dts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -441,7 +454,7 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((dts)&0x7fff) << 1) | 1);
+        val = int32_t((((dts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
@@ -450,10 +463,10 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
     video_pes_segs_.clear();
     video_pes_segs_.emplace_back(std::string_view(video_pes_header_, video_pes_len));
 
-    static char annexb_start_code1[] = { 0x00, 0x00, 0x01 };
-    static char annexb_start_code2[] = { 0x00, 0x00, 0x00, 0x01 };    
+    static char annexb_start_code1[] = {0x00, 0x00, 0x01};
+    static char annexb_start_code2[] = {0x00, 0x00, 0x00, 0x01};
     bool first_nalu = true;
-    for (auto & nalu : nalus) {
+    for (auto &nalu : nalus) {
         if (first_nalu) {
             first_nalu = false;
             video_pes_segs_.emplace_back(std::string_view(annexb_start_code2, 4));
@@ -468,9 +481,9 @@ void RtspToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> 
     }
 
     pes_packet->alloc_buf(video_pes_len);
-    for (auto & seg : video_pes_segs_) {
+    for (auto &seg : video_pes_segs_) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
 
@@ -486,25 +499,26 @@ void RtspToTs::process_h265_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h265_nalu = rtp_h265_depacketizer_.on_packet(pkt);
     if (h265_nalu) {
         int64_t this_timestamp = h265_nalu->get_timestamp();
-        generate_h265_ts((this_timestamp - first_rtp_video_ts_)/90, h265_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        generate_h265_ts((this_timestamp - first_rtp_video_ts_) / 90,
+                         h265_nalu);  // todo 除90这个要根据sdp来计算，目前固定
     }
 }
 
-void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> & nalu) {
+void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
 
     std::string_view sps;
     std::string_view pps;
     std::string_view vps;
     std::list<std::string_view> nalus;
-    HevcCodec *hevc_codec = (HevcCodec*)video_codec_.get();
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    HevcCodec *hevc_codec = (HevcCodec *)video_codec_.get();
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
         H265RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_single_nalu()) {
             if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP && pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
                 is_key = true;
@@ -515,7 +529,8 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
             buf += 4;
             memcpy(buf, pkt->get_payload().data(), pkt->get_payload().size());
 
-            nalus.emplace_back(std::string_view((char*)pkt->get_payload().data(), pkt->get_payload().size()));
+            nalus.emplace_back(
+                std::string_view((char *)pkt->get_payload().data(), pkt->get_payload().size()));
             buf += pkt->get_payload().size();
 
             if (pkt_info.get_nalu_type() == NAL_VPS) {
@@ -528,26 +543,27 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
 
             if (pkt->get_header().marker == 1) {
                 break;
-            } 
+            }
         } else if (pkt_info.is_fu()) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
-            char * buf_data_start = buf;
+            char *buf_data_start = buf;
             if (pkt_info.is_start_fu()) {
                 do {
                     if (pkt_info.is_start_fu()) {
-                        if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP && pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
+                        if (pkt_info.get_nalu_type() >= NAL_BLA_W_LP &&
+                            pkt_info.get_nalu_type() <= NAL_RSV_IRAP_VCL23) {
                             is_key = true;
                         }
 
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
                         uint8_t p0 = *pkt_buf;
                         uint8_t p1 = *(pkt_buf + 1);
-                        uint8_t fu_header = pkt_buf[2]; // FU header
-                        uint8_t fu_type = fu_header & 0x3F; // 提取低6位FuType
+                        uint8_t fu_header = pkt_buf[2];      // FU header
+                        uint8_t fu_type = fu_header & 0x3F;  // 提取低6位FuType
 
-                        buf[0] = (p0 & 0x81) | (fu_type << 1); // 假设Type占6位，调整掩码和移位
+                        buf[0] = (p0 & 0x81) | (fu_type << 1);  // 假设Type占6位，调整掩码和移位
                         buf[1] = p1;
                         memcpy(buf + 2, pkt->get_payload().data() + 3, pkt->get_payload().size() - 3);
                         buf += pkt->get_payload().size() - 1;
@@ -557,7 +573,7 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
                         buf += pkt->get_payload().size() - 3;
                         nalu_size += pkt->get_payload().size() - 3;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         if (pkt_info.get_nalu_type() == NAL_VPS) {
@@ -579,13 +595,13 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
                     }
                 } while (pkt_info.is_fu() && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 break;
             } else {
                 spdlog::error("H264_RTP_PAYLOAD_FU_A nalu not marker");
             }
-        } 
+        }
     }
 
     if (vps.size() > 0) {
@@ -607,7 +623,7 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
         wait_first_key_frame_ = false;
     }
 
-    if (!curr_seg_ && !is_key) {//片段开始的帧，必须是关键帧
+    if (!curr_seg_ && !is_key) {  // 片段开始的帧，必须是关键帧
         return;
     }
 
@@ -626,10 +642,10 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
         create_pmt(pmt_seg);
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
-    
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
+
     // 判断sps,pps,aud等
     // bool has_aud_nalu = false;
     bool has_vps_nalu = false;
@@ -649,9 +665,12 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
             hevc_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type >= NAL_BLA_W_LP && nalu_type <= NAL_RSV_IRAP_VCL23) {
             if (!has_pps_nalu && !has_sps_nalu && !has_vps_nalu) {
-                it = nalus.insert(it, std::string_view(hevc_codec->get_pps_nalu().data(), hevc_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(hevc_codec->get_sps_nalu().data(), hevc_codec->get_sps_nalu().size()));
-                it = nalus.insert(it, std::string_view(hevc_codec->get_vps_nalu().data(), hevc_codec->get_vps_nalu().size()));
+                it = nalus.insert(it, std::string_view(hevc_codec->get_pps_nalu().data(),
+                                                       hevc_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(hevc_codec->get_sps_nalu().data(),
+                                                       hevc_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(hevc_codec->get_vps_nalu().data(),
+                                                       hevc_codec->get_vps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
                 has_vps_nalu = true;
@@ -659,22 +678,21 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
         }
     }
 
-    
     // static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
     // static std::string_view aud_nalu((char*)default_aud_nalu, 2);
     // if (!has_aud_nalu) {
     //     nalus.push_front(aud_nalu);
     // }
     // 计算payload长度(第一个nalu头部4个字节，后面的头部只需要3字节)
-    int32_t payload_size = nalus.size()*3 + 1;//头部的总字节数
-    for (auto & nalu : nalus) {
+    int32_t payload_size = nalus.size() * 3 + 1;  // 头部的总字节数
+    for (auto &nalu : nalus) {
         payload_size += nalu.size();
     }
 
     // 添加上pes header
     // uint8_t *pes = video_pes_.get();
     char *pes = video_pes_header_;
-    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};//固定3字节头,跟annexb没什么关系
+    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};  // 固定3字节头,跟annexb没什么关系
     memcpy(pes, pes_start_prefix, 3);
     pes += 3;
     // stream_id
@@ -682,40 +700,40 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
     // PES_packet_length
     uint8_t PTS_DTS_flags = 0x03;
     // if (header.composition_time == 0) {//dts = pts时，只需要dts
-        PTS_DTS_flags = 0x02;
+    PTS_DTS_flags = 0x02;
     // }
 
-    //PES_header_data_length
+    // PES_header_data_length
     uint8_t PES_header_data_length = 0;
     if (PTS_DTS_flags == 0x02) {
-        PES_header_data_length = 5;//DTS 5字节
+        PES_header_data_length = 5;  // DTS 5字节
     } else if (PTS_DTS_flags == 0x03) {
-        PES_header_data_length = 10;//PTS 5字节
+        PES_header_data_length = 10;  // PTS 5字节
     }
 
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    if (PTS_DTS_flags & 0x02) {// 填充pts
+    if (PTS_DTS_flags & 0x02) {  // 填充pts
         // uint64_t pts = (video_pkt->timestamp_ + header.composition_time)*90;
-        uint64_t pts = timestamp*90;
+        uint64_t pts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x02 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -724,13 +742,13 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((pts)&0x7fff) << 1) | 1);
+        val = int32_t((((pts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
 
-    if (PTS_DTS_flags & 0x01) {// 填充dts
-        uint64_t dts = timestamp*90;
+    if (PTS_DTS_flags & 0x01) {  // 填充dts
+        uint64_t dts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -739,7 +757,7 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((dts)&0x7fff) << 1) | 1);
+        val = int32_t((((dts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
@@ -748,10 +766,10 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
     video_pes_segs_.clear();
     video_pes_segs_.emplace_back(std::string_view(video_pes_header_, video_pes_len));
 
-    static char annexb_start_code1[] = { 0x00, 0x00, 0x01 };
-    static char annexb_start_code2[] = { 0x00, 0x00, 0x00, 0x01 };    
+    static char annexb_start_code1[] = {0x00, 0x00, 0x01};
+    static char annexb_start_code2[] = {0x00, 0x00, 0x00, 0x01};
     bool first_nalu = true;
-    for (auto & nalu : nalus) {
+    for (auto &nalu : nalus) {
         if (first_nalu) {
             first_nalu = false;
             video_pes_segs_.emplace_back(std::string_view(annexb_start_code2, 4));
@@ -767,9 +785,9 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
     }
 
     pes_packet->alloc_buf(video_pes_len);
-    for (auto & seg : video_pes_segs_) {
+    for (auto &seg : video_pes_segs_) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
 
@@ -781,23 +799,23 @@ void RtspToTs::generate_h265_ts(int64_t timestamp, std::shared_ptr<RtpH265NALU> 
     ts_media_source_->on_pes_packet(pes_packet);
 }
 
-void RtspToTs::create_pat(std::string_view & data) {
-    uint8_t *buf = (uint8_t*)data.data();
+void RtspToTs::create_pat(std::string_view &data) {
+    uint8_t *buf = (uint8_t *)data.data();
     /*********************** ts header *********************/
-    *buf++ = 0x47;//ts header sync byte
+    *buf++ = 0x47;  // ts header sync byte
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TsPidPAT
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TsPidPAT;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
     // continuity_counter_(4b)   = 0
     *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | 00;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf++ = 0;
     uint8_t *pat_start = buf;
     // table_id
@@ -809,28 +827,32 @@ void RtspToTs::create_pat(std::string_view & data) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//transport_stream_id(2B) + current_next_indicator(1B) + section_number(1B) + last_section_number(1B) + crc
+    int16_t section_len = 5 + 4 + 4;  // transport_stream_id(2B) + current_next_indicator(1B) +
+                                      // section_number(1B) + last_section_number(1B) + crc
     int16_t slv = section_len & 0x0FFF;
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
-    //transport_stream_id
-    *((uint16_t*)buf) = htons(0x0001);//transport_stream_id
+    // transport_stream_id
+    *((uint16_t *)buf) = htons(0x0001);  // transport_stream_id
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf++ = cniv;
     // section_number
     *buf++ = 0;
@@ -843,26 +865,25 @@ void RtspToTs::create_pat(std::string_view & data) {
     v32 = (pmt_pid & 0x1FFF) | (0x07 << 13) | ((pmt_number << 16) & 0xFFFF0000);
     *((uint32_t *)buf) = htonl(v32);
     buf += 4;
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pat_start, buf - pat_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)data.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)data.data() + 188 - buf);
     return;
 }
 
-
-void RtspToTs::create_pmt(std::string_view & pmt_seg) {
-    uint8_t *buf = (uint8_t*)pmt_seg.data();
+void RtspToTs::create_pmt(std::string_view &pmt_seg) {
+    uint8_t *buf = (uint8_t *)pmt_seg.data();
     /*********************** ts header *********************/
-    *buf = 0x47;//ts header sync byte
+    *buf = 0x47;  // ts header sync byte
     buf++;
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TS_PMT_PID
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TS_PMT_PID;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
@@ -870,7 +891,7 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
     *buf = (TsAdapationControlPayloadOnly << 4);
     buf++;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf = 0;
     buf++;
     uint8_t *pmt_start = buf;
@@ -884,15 +905,19 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
+    int16_t section_len =
+        5 + 4 + 4;  // 5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
     if (has_video_) {
         section_len += 5;
     }
@@ -904,16 +929,16 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
 
     // program number
-    *((uint16_t*)buf) = htons(TS_PMT_NUMBER);//program number
+    *((uint16_t *)buf) = htons(TS_PMT_NUMBER);  // program number
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf = cniv;
     buf++;
     // section_number
@@ -922,30 +947,30 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
     // last_section_number
     *buf = 0;
     buf++;
-    // reserved 3 bslbf 
+    // reserved 3 bslbf
     // PCR_PID 13 uimsbf
     // 2B
     int16_t ppv = PCR_PID & 0x1FFF;
     ppv |= (7 << 13) & 0xE000;
-    *((uint16_t*)buf) = htons(ppv);
+    *((uint16_t *)buf) = htons(ppv);
     buf += 2;
-    // reserved 4 bslbf 
+    // reserved 4 bslbf
     // program_info_length 12 0
     // 2B
     int16_t pilv = 0 & 0xFFF;
     pilv |= (0xf << 12) & 0xF000;
-    *((uint16_t*)buf) = htons(pilv);
+    *((uint16_t *)buf) = htons(pilv);
     buf += 2;
-    // for (i = 0; i < N1; i++) { 
-    //     stream_type 8 uimsbf 
-    //     reserved 3 bslbf 
-    //     elementary_PID 13 uimsbf 
-        
-    //     reserved 4 bslbf 
-    //     ES_info_length 12 uimsbf 
-    //     for (i = 0; i < N2; i++) { 
-    //         descriptor() 
-    //     } 
+    // for (i = 0; i < N1; i++) {
+    //     stream_type 8 uimsbf
+    //     reserved 3 bslbf
+    //     elementary_PID 13 uimsbf
+
+    //     reserved 4 bslbf
+    //     ES_info_length 12 uimsbf
+    //     for (i = 0; i < N2; i++) {
+    //         descriptor()
+    //     }
     // }
 
     if (has_audio_) {
@@ -953,11 +978,11 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = audio_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
@@ -966,19 +991,19 @@ void RtspToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = video_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pmt_start, buf - pmt_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)pmt_seg.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)pmt_seg.data() + 188 - buf);
     return;
 }
 
@@ -993,11 +1018,11 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
 
         uint8_t payload_unit_start_indicator = 0;
-        if (left_count == pes_len) {// 第一个ts切片，置上标志位
+        if (left_count == pes_len) {  // 第一个ts切片，置上标志位
             payload_unit_start_indicator = 1;
         }
         // transport_error_indicator(1b)        0
@@ -1005,12 +1030,11 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
         // transport_priority(1b)               0
         // pid(13b)                             TsPidPAT
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | video_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
 
-        
         bool write_pcr = false;
-        if (left_count == pes_len) {// 第一个切片
+        if (left_count == pes_len) {  // 第一个切片
             if (PCR_PID == video_pid_ && is_key) {
                 write_pcr = true;
             }
@@ -1025,16 +1049,17 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
         // adaptation_field_control(2b) = payload only
         // continuity_counter_(4b)   = 0
         if (write_pcr || write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
         }
         continuity_counter_[video_pid_]++;
 
         int adaptation_field_total_length = 0;
         if (write_pcr) {
             // adaptation_field_length
-            adaptation_field_total_length = 8;// adaptation_field_length(1) + flags(1) + PCR(6) = 8
+            adaptation_field_total_length = 8;  // adaptation_field_length(1) + flags(1) + PCR(6) = 8
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -1045,14 +1070,14 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
             if (staffing_count > 0) {
                 adaptation_field_total_length += staffing_count;
             }
-            int adaptation_field_length = adaptation_field_total_length - 1;// 需要减掉自己的1字节
+            int adaptation_field_length = adaptation_field_total_length - 1;  // 需要减掉自己的1字节
             *buf++ = adaptation_field_length;
-            *buf++ = 0x10;// (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
-            int64_t pcrv = (0) & 0x1ff;//program_clock_reference_base
-            pcrv |= (0x3f << 9) & 0x7E00;//reserved
+            *buf++ = 0x10;                 // (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
+            int64_t pcrv = (0) & 0x1ff;    // program_clock_reference_base
+            pcrv |= (0x3f << 9) & 0x7E00;  // reserved
             pcrv |= (pes_packet->pes_header.dts << 15) & 0xFFFFFFFF8000LL;
 
-            char *pp = (char*)&pcrv;
+            char *pp = (char *)&pcrv;
             *buf++ = pp[5];
             *buf++ = pp[4];
             *buf++ = pp[3];
@@ -1066,7 +1091,7 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
         }
 
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -1079,7 +1104,7 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -1094,12 +1119,12 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 video_pes_segs_[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -1111,7 +1136,6 @@ void RtspToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t pe
     }
     pes_packet->ts_bytes = ts_total_bytes;
 }
-
 
 void RtspToTs::process_audio_packet(std::shared_ptr<RtpPacket> pkt, int64_t timestamp) {
     if (!audio_codec_) {
@@ -1133,7 +1157,8 @@ void RtspToTs::process_aac_packet(std::shared_ptr<RtpPacket> pkt, int64_t timest
         if (!audio_config) {
             return;
         }
-        generate_aac_ts(((this_timestamp - first_rtp_audio_ts_)*1000)/audio_config->sampling_frequency, aac_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        generate_aac_ts(((this_timestamp - first_rtp_audio_ts_) * 1000) / audio_config->sampling_frequency,
+                        aac_nalu);  // todo 除90这个要根据sdp来计算，目前固定
     }
 }
 
@@ -1144,29 +1169,29 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
     if (!au_config) {
         return;
     }
-    int16_t au_per_header_bytes = (au_config->size_length + au_config->index_length + 7)/8;
+    int16_t au_per_header_bytes = (au_config->size_length + au_config->index_length + 7) / 8;
 
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     std::vector<std::string_view> segs;
     int32_t frame_length = 0;
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
-        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
+        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
         int32_t left_bytes = pkt->get_payload().size();
         const uint8_t *au_section_buf;
-        if (au_config->size_length != 0) {//有sizelength参数
-            uint16_t au_header_bits = ntohs(*(uint16_t*)pkt_buf);
+        if (au_config->size_length != 0) {  // 有sizelength参数
+            uint16_t au_header_bits = ntohs(*(uint16_t *)pkt_buf);
             size_t au_header_bytes_total = au_header_bits / 8;
-            uint16_t au_header_count = au_header_bytes_total/au_per_header_bytes;
+            uint16_t au_header_count = au_header_bytes_total / au_per_header_bytes;
             // 检查头部长度的完整性
             if (size_t(au_header_count * au_per_header_bytes) != au_header_bytes_total) {
                 return;
             }
 
-            BitStream bit_stream(std::string_view((char*)pkt_buf + 2, au_header_bytes_total));
+            BitStream bit_stream(std::string_view((char *)pkt_buf + 2, au_header_bytes_total));
             au_section_buf = pkt_buf + 2 + au_header_bytes_total;
             left_bytes -= 2 + au_header_bytes_total;
-            for(auto i = 0; i < au_header_count; i++) {
+            for (auto i = 0; i < au_header_count; i++) {
                 uint16_t au_size = 0;
                 if (!bit_stream.read_u(au_config->size_length, au_size)) {
                     return;
@@ -1186,7 +1211,7 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                     copy_bytes = left_bytes;
                 }
 
-                segs.push_back(std::string_view((char*)au_section_buf, copy_bytes));
+                segs.push_back(std::string_view((char *)au_section_buf, copy_bytes));
                 au_section_buf += copy_bytes;
                 frame_length += copy_bytes;
             }
@@ -1208,7 +1233,7 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                 }
 
                 frame_length += 7;
-                auto & adts_header = adts_headers_[adts_header_index_];
+                auto &adts_header = adts_headers_[adts_header_index_];
                 adts_header.data[0] = 0xff;
                 adts_header.data[1] = 0xf9;
                 adts_header.data[2] = (aac_profile << 6) & 0xc0;
@@ -1235,9 +1260,9 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                     }
                 }
 
-                auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-                auto & pes_header = pes_packet->pes_header;
-                memset((void*)&pes_header, 0, sizeof(pes_header));
+                auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+                auto &pes_header = pes_packet->pes_header;
+                memset((void *)&pes_header, 0, sizeof(pes_header));
 
                 audio_buf_.audio_pkts.emplace_back(nalu);
                 if (audio_buf_.audio_pes_len == 0) {
@@ -1247,7 +1272,7 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                 audio_buf_.audio_pes_segs.emplace_back(std::string_view(adts_header.data, 7));
                 audio_buf_.audio_pes_segs.insert(audio_buf_.audio_pes_segs.end(), segs.begin(), segs.end());
                 audio_buf_.audio_pes_len += frame_length;
-                if (audio_buf_.audio_pes_len < 1400) {//至少1400字节，再一起送切片
+                if (audio_buf_.audio_pes_len < 1400) {  // 至少1400字节，再一起送切片
                     return;
                 }
 
@@ -1266,31 +1291,31 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                 // stream_id
                 *pes++ = TsPESStreamIdAudioCommon;
                 uint8_t PTS_DTS_flags = 0x02;
-                uint8_t PES_header_data_length = 5;//只有pts
+                uint8_t PES_header_data_length = 5;  // 只有pts
                 // int32_t payload_size = 7 + payload.size() - header_consumed;//adts header + payload
                 int32_t payload_size = audio_buf_.audio_pes_len;
                 uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-                uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-                *((uint16_t*)pes) = htons(PES_packet_length);
+                uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+                *((uint16_t *)pes) = htons(PES_packet_length);
                 pes += 2;
                 // 10' 2 bslbf
-                // PES_scrambling_control 2 bslbf 
-                // PES_priority 1 bslbf 
-                // data_alignment_indicator 1 bslbf 
-                // copyright 1 bslbf 
-                // original_or_copy 1 bslbf 
+                // PES_scrambling_control 2 bslbf
+                // PES_priority 1 bslbf
+                // data_alignment_indicator 1 bslbf
+                // copyright 1 bslbf
+                // original_or_copy 1 bslbf
                 *pes++ = 0x80;
-                // PTS_DTS_flags 2 bslbf 
-                // ESCR_flag 1 bslbf 
-                // ES_rate_flag 1 bslbf 
-                // DSM_trick_mode_flag 1 bslbf 
-                // additional_copy_info_flag 1 bslbf 
-                // PES_CRC_flag 1 bslbf 
+                // PTS_DTS_flags 2 bslbf
+                // ESCR_flag 1 bslbf
+                // ES_rate_flag 1 bslbf
+                // DSM_trick_mode_flag 1 bslbf
+                // additional_copy_info_flag 1 bslbf
+                // PES_CRC_flag 1 bslbf
                 // PES_extension_flag
                 *pes++ = PTS_DTS_flags << 6;
                 *pes++ = PES_header_data_length;
-                //audio pts
-                uint64_t pts = audio_buf_.timestamp*90;
+                // audio pts
+                uint64_t pts = audio_buf_.timestamp * 90;
                 int32_t val = 0;
                 val = int32_t(0x03 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
                 *pes++ = val;
@@ -1299,7 +1324,7 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                 *pes++ = (val >> 8);
                 *pes++ = val;
 
-                val = int32_t((((pts)&0x7fff) << 1) | 1);
+                val = int32_t((((pts) & 0x7fff) << 1) | 1);
                 *pes++ = (val >> 8);
                 *pes++ = val;
 
@@ -1310,7 +1335,7 @@ void RtspToTs::generate_aac_ts(int64_t timestamp, std::shared_ptr<RtpAACNALU> na
                 pes_packet->alloc_buf(audio_buf_.audio_pes_len);
                 for (auto seg : audio_buf_.audio_pes_segs) {
                     auto unuse_payload = pes_packet->get_unuse_data();
-                    memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+                    memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
                     pes_packet->inc_used_bytes(seg.size());
                 }
 
@@ -1338,8 +1363,8 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
         // transport_error_indicator(1b)        0
         // payload_unit_start_indicator(1b)     1
         // transport_priority(1b)               0
@@ -1349,7 +1374,7 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             payload_unit_start_indicator = 1;
         }
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | audio_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
         // transport_scrambling_control(2b) = 00
         // adaptation_field_control(2b) = payload only
@@ -1360,15 +1385,16 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         }
 
         if (write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         }
 
         continuity_counter_[audio_pid_]++;
         int adaptation_field_total_length = 0;
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -1381,7 +1407,7 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -1397,12 +1423,12 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 audio_buf_.audio_pes_segs[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -1414,9 +1440,7 @@ void RtspToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
     pes_packet->ts_bytes = ts_total_bytes;
 }
 
-void RtspToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) {
-    ts_media_source_->on_ts_segment(seg);
-}
+void RtspToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) { ts_media_source_->on_ts_segment(seg); }
 
 void RtspToTs::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
@@ -1424,28 +1448,31 @@ void RtspToTs::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
-        
-        if (ts_media_source_) {
-            ts_media_source_->close();
-            ts_media_source_ = nullptr;
-        }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        auto origin_source = origin_source_.lock();
-        if (rtp_media_sink_) {
-            rtp_media_sink_->set_source_codec_ready_cb({});
-            rtp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtp_media_sink_);
+            if (ts_media_source_) {
+                ts_media_source_->close();
+                ts_media_source_ = nullptr;
             }
-            rtp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtp_media_sink_) {
+                rtp_media_sink_->set_source_codec_ready_cb({});
+                rtp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtp_media_sink_);
+                }
+                rtp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/ts/ts_to_hls.cpp
+++ b/live-server/bridge/ts/ts_to_hls.cpp
@@ -3,73 +3,87 @@
  * @Date: 2023-07-02 10:56:59
  * @LastEditTime: 2023-12-27 20:04:26
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\ts_to_hls.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "ts_to_hls.hpp"
+
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
 #include <boost/asio/redirect_error.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/asio/detached.hpp>
 
-#include "ts_to_hls.hpp"
-#include "base/thread/thread_worker.hpp"
-#include "core/ts_media_sink.hpp"
-#include "core/hls_live_media_source.hpp"
-#include "log/log.h"
 #include "app/publish_app.h"
+#include "base/thread/thread_worker.hpp"
 #include "config/app_config.h"
+#include "core/hls_live_media_source.hpp"
+#include "core/ts_media_sink.hpp"
+#include "log/log.h"
+
 
 using namespace mms;
-TsToHls::TsToHls(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
+TsToHls::TsToHls(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                 std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                 const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
     sink_ = std::make_shared<TsMediaSink>(worker);
     ts_media_sink_ = std::static_pointer_cast<TsMediaSink>(sink_);
-    source_ = std::make_shared<HlsLiveMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<HlsLiveMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     hls_media_source_ = std::static_pointer_cast<HlsLiveMediaSource>(source_);
     type_ = "ts-to-hls";
 }
 
-TsToHls::~TsToHls() {
-
-}
+TsToHls::~TsToHls() {}
 
 bool TsToHls::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto app_conf = publish_app_->get_conf();
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(app_conf->bridge_config().no_players_timeout_ms()/2));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto app_conf = publish_app_->get_conf();
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(
+                    app_conf->bridge_config().no_players_timeout_ms() / 2));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (hls_media_source_->has_no_sinks_for_time(app_conf->bridge_config().no_players_timeout_ms())) {//已经30秒没人播放了
-                CORE_DEBUG("close TsToHls because no players for 30s");
-                break;
+                if (hls_media_source_->has_no_sinks_for_time(
+                        app_conf->bridge_config().no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    CORE_DEBUG("close TsToHls because no players for 30s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    ts_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-        hls_media_source_->set_status(status);
-        if (status == E_SOURCE_STATUS_OK) {
-            ts_media_sink_->on_ts_segment([this, self](std::shared_ptr<TsSegment> seg)->boost::asio::awaitable<bool> {
-                hls_media_source_->on_ts_segment(seg);
-                co_return true;
-            });
-        }
-        co_return;
-    });
-    return true;    
+    ts_media_sink_->set_on_source_status_changed_cb(
+        [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+            hls_media_source_->set_status(status);
+            if (status == E_SOURCE_STATUS_OK) {
+                ts_media_sink_->on_ts_segment(
+                    [this, self](std::shared_ptr<TsSegment> seg) -> boost::asio::awaitable<bool> {
+                        hls_media_source_->on_ts_segment(seg);
+                        co_return true;
+                    });
+            }
+            co_return;
+        });
+    return true;
 }
 
 void TsToHls::close() {
@@ -78,28 +92,31 @@ void TsToHls::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
-        
-        if (hls_media_source_) {
-            hls_media_source_->close();
-            hls_media_source_ = nullptr;
-        }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        auto origin_source = origin_source_.lock();
-        if (ts_media_sink_) {
-            ts_media_sink_->on_ts_segment({});
-            ts_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(ts_media_sink_);
+            if (hls_media_source_) {
+                hls_media_source_->close();
+                hls_media_source_ = nullptr;
             }
-            ts_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (ts_media_sink_) {
+                ts_media_sink_->on_ts_segment({});
+                ts_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(ts_media_sink_);
+                }
+                ts_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/webrtc/webrtc_to_flv.cpp
+++ b/live-server/bridge/webrtc/webrtc_to_flv.cpp
@@ -1,36 +1,39 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/redirect_error.hpp>
-#include <boost/system/error_code.hpp>
-
 #include "webrtc_to_flv.hpp"
 
-#include "base/thread/thread_worker.hpp"
-
-#include "core/rtp_media_sink.hpp"
-#include "core/flv_media_source.hpp"
-
-#include "codec/codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/opus/opus_codec.hpp"
-#include "codec/h264/h264_codec.hpp"
-#include "codec/aac/aac_encoder.hpp"
-#include "codec/hevc/hevc_codec.hpp"
-
-#include "protocol/rtmp/flv/flv_define.hpp"
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/system/error_code.hpp>
 
 #include "app/publish_app.h"
+#include "base/thread/thread_worker.hpp"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/aac_encoder.hpp"
+#include "codec/codec.hpp"
+#include "codec/h264/h264_codec.hpp"
+#include "codec/hevc/hevc_codec.hpp"
+#include "codec/opus/opus_codec.hpp"
+#include "core/flv_media_source.hpp"
+#include "core/rtp_media_sink.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+
 
 using namespace mms;
 
-WebRtcToFlv::WebRtcToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<FlvMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+WebRtcToFlv::WebRtcToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                         std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                         const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<FlvMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     flv_media_source_ = std::static_pointer_cast<FlvMediaSource>(source_);
-    sink_ = std::make_shared<RtpMediaSink>(worker); 
+    sink_ = std::make_shared<RtpMediaSink>(worker);
     rtp_media_sink_ = std::static_pointer_cast<RtpMediaSink>(sink_);
-    video_frame_cache_ = std::make_unique<char[]>(1024*1024);
-    audio_frame_cache_ = std::make_unique<char[]>(1024*20);
+    video_frame_cache_ = std::make_unique<char[]>(1024 * 1024);
+    audio_frame_cache_ = std::make_unique<char[]>(1024 * 20);
     if (swr_context_) {
         swr_free(&swr_context_);
         swr_context_ = nullptr;
@@ -38,35 +41,38 @@ WebRtcToFlv::WebRtcToFlv(ThreadWorker *worker, std::shared_ptr<PublishApp> app, 
     type_ = "webrtc-to-flv";
 }
 
-WebRtcToFlv::~WebRtcToFlv() {
-    spdlog::debug("destroy WebRtcToFlv");
-}
+WebRtcToFlv::~WebRtcToFlv() { spdlog::debug("destroy WebRtcToFlv"); }
 
 bool WebRtcToFlv::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(30000));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(30000));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (flv_media_source_->has_no_sinks_for_time(30000)) {//已经30秒没人播放了
-                spdlog::debug("close WebRtcToFlv because no players for 30s");
-                break;
+                if (flv_media_source_->has_no_sinks_for_time(30000)) {  // 已经30秒没人播放了
+                    spdlog::debug("close WebRtcToFlv because no players for 30s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec)->bool {
+    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec,
+                                                            std::shared_ptr<Codec> audio_codec) -> bool {
         video_codec_ = video_codec;
         audio_codec_ = audio_codec;
         if (video_codec_) {
@@ -78,17 +84,15 @@ bool WebRtcToFlv::init() {
                 return false;
             }
 
-            OpusCodec *opus_codec = (OpusCodec*)audio_codec_.get();
+            OpusCodec *opus_codec = (OpusCodec *)audio_codec_.get();
             opus_decoder_ = opus_codec->create_decoder(opus_codec->getFs(), opus_codec->get_channels());
             if (!swr_context_) {
                 AVChannelLayout out_ch_layout;
                 AVChannelLayout in_ch_layout;
                 av_channel_layout_default(&out_ch_layout, 2);
                 av_channel_layout_default(&in_ch_layout, opus_codec->get_channels());
-                int ret = swr_alloc_set_opts2(&swr_context_,
-                                    &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                                    &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 
-                                    0, NULL);
+                int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
+                                              &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 0, NULL);
                 if (ret < 0) {
                     spdlog::error("swr init failed");
                     return false;
@@ -115,33 +119,35 @@ bool WebRtcToFlv::init() {
         return generateFlvHeaders();
     });
 
-    rtp_media_sink_->set_video_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_video_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_video_ts_ = pkts[0]->get_timestamp();
+    rtp_media_sink_->set_video_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_video_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_video_ts_ = pkts[0]->get_timestamp();
+                }
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_video_packet(pkt);
-        }
-        
-        co_return true;
-    });
-
-    rtp_media_sink_->set_audio_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_audio_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+            for (auto pkt : pkts) {
+                process_video_packet(pkt);
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_audio_packet(pkt);
-        }
-        
-        co_return true;
-    });
+            co_return true;
+        });
+
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_audio_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+                }
+            }
+
+            for (auto pkt : pkts) {
+                process_audio_packet(pkt);
+            }
+
+            co_return true;
+        });
 
     return true;
 }
@@ -200,7 +206,7 @@ bool WebRtcToFlv::generate_metadata() {
         "width" : 1280.0
     }
     */
-    Amf0String name1; 
+    Amf0String name1;
     name1.set_value("@setDataFrame");
     Amf0String name2;
     name2.set_value("onMetaData");
@@ -211,7 +217,7 @@ bool WebRtcToFlv::generate_metadata() {
     metadata_amf0_.set_item_value("4.1", false);
     metadata_amf0_.set_item_value("5.1", false);
     metadata_amf0_.set_item_value("7.1", false);
-    metadata_amf0_.set_item_value("audiocodecid", 10.0);//aac
+    metadata_amf0_.set_item_value("audiocodecid", 10.0);  // aac
     // 固定值
     if (audio_codec_->get_codec_type() == CODEC_AAC) {
         auto aac_codec = std::static_pointer_cast<AACCodec>(audio_codec_);
@@ -227,7 +233,7 @@ bool WebRtcToFlv::generate_metadata() {
             metadata_amf0_.set_item_value("stereo", false);
         }
         metadata_amf0_.set_item_value("audiodatarate", (double)audio_codec_->get_data_rate());
-        metadata_amf0_.set_item_value("audiosamplesize", 16.0);//好像aac是固定的16bit
+        metadata_amf0_.set_item_value("audiosamplesize", 16.0);  // 好像aac是固定的16bit
     } else {
         return false;
     }
@@ -260,14 +266,14 @@ bool WebRtcToFlv::generate_metadata() {
     metadata_pkt_->tag_header.data_size = total_bytes;
 
     auto unuse_data = metadata_pkt_->get_unuse_data();
-    uint8_t* payload = (uint8_t*)unuse_data.data() + FLV_TAG_HEADER_BYTES;
+    uint8_t *payload = (uint8_t *)unuse_data.data() + FLV_TAG_HEADER_BYTES;
     size_t payload_bytes = unuse_data.size() - FLV_TAG_HEADER_BYTES;
     int32_t consumed1 = name1.encode(payload, payload_bytes);
     int32_t consumed2 = name2.encode(payload + consumed1, payload_bytes - consumed1);
     metadata_amf0_.encode(payload + consumed1 + consumed2, payload_bytes - consumed1 - consumed2);
 
     auto script_data = std::make_unique<SCRIPTDATA>();
-    script_data->payload = std::string_view((char*)payload, total_bytes);
+    script_data->payload = std::string_view((char *)payload, total_bytes);
     metadata_pkt_->tag_data = std::move(script_data);
     metadata_pkt_->encode();
     return true;
@@ -283,7 +289,7 @@ bool WebRtcToFlv::generate_video_header() {
     auto video_data = std::make_unique<VIDEODATA>();
     if (video_codec_->get_codec_type() == CODEC_H264) {
         auto h264_codec = std::static_pointer_cast<H264Codec>(video_codec_);
-        AVCDecoderConfigurationRecord & decode_configuration_record = h264_codec->get_avc_configuration();
+        AVCDecoderConfigurationRecord &decode_configuration_record = h264_codec->get_avc_configuration();
         auto payload_size = decode_configuration_record.size();
         // 5 video tag header
         video_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + payload_size);
@@ -296,11 +302,11 @@ bool WebRtcToFlv::generate_video_header() {
         video_data->header.codec_id = VideoTagHeader::AVC;
         video_data->header.avc_packet_type = VideoTagHeader::AVCSequenceHeader;
         video_data->header.composition_time = 0;
-        
+
         video_header_->tag_header.data_size = 5 + payload_size;
         auto payload = video_header_->get_unuse_data();
         payload.remove_prefix(FLV_TAG_HEADER_BYTES + 5);
-        auto ret = decode_configuration_record.encode((uint8_t*)payload.data(), payload.size());
+        auto ret = decode_configuration_record.encode((uint8_t *)payload.data(), payload.size());
         if (ret < 0) {
         } else {
         }
@@ -317,7 +323,7 @@ bool WebRtcToFlv::generate_video_header() {
         }
         return true;
     }
-    
+
     return false;
 }
 
@@ -341,12 +347,14 @@ bool WebRtcToFlv::generate_audio_header() {
         } else {
             audio_data->header.sound_rate = AudioTagHeader::KHZ_44;
         }
-        
+
         audio_data->header.sound_size = AudioTagHeader::Sample_16bit;
         audio_data->header.aac_packet_type = AudioTagHeader::AACSequenceHeader;
 
         auto payload_size = audio_config->size();
-        audio_header_ = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 + payload_size);//11字节flv tag头+2字节aac头+audio_specific_config字节数
+        audio_header_ =
+            std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 +
+                                     payload_size);  // 11字节flv tag头+2字节aac头+audio_specific_config字节数
         audio_header_->tag_header.tag_type = FlvTagHeader::AudioTag;
         audio_header_->tag_header.data_size = 2 + payload_size;
         audio_header_->tag_header.stream_id = 0;
@@ -354,7 +362,7 @@ bool WebRtcToFlv::generate_audio_header() {
 
         auto payload = audio_header_->get_unuse_data();
         payload.remove_prefix(FLV_TAG_HEADER_BYTES + 2);
-        auto ret = audio_config->encode((uint8_t*)payload.data(), payload.size());
+        auto ret = audio_config->encode((uint8_t *)payload.data(), payload.size());
         if (ret < 0) {
             return false;
         }
@@ -371,42 +379,44 @@ void WebRtcToFlv::process_video_packet(std::shared_ptr<RtpPacket> pkt) {
     if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
         process_h264_packet(pkt);
     }
-} 
+}
 
 void WebRtcToFlv::process_h264_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h264_nalu = rtp_h264_depacketizer_.on_packet(pkt);
     if (h264_nalu) {
         uint32_t this_timestamp = h264_nalu->get_timestamp();
-        auto flv_tag = generate_h264_flv_tag((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        auto flv_tag = generate_h264_flv_tag((this_timestamp - first_rtp_video_ts_) / 90,
+                                             h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
         if (flv_tag) {
             flv_media_source_->on_video_packet(flv_tag);
         }
     }
 }
 
-std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp,
+                                                           std::shared_ptr<RtpH264NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     int32_t total_payload_bytes = 0;
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
 
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
                     is_key = true;
                 }
-                
+
                 uint32_t s = htonl(nalu_size);
                 memcpy(buf, &s, 4);
                 buf += 4;
@@ -417,16 +427,18 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                 data += 2 + nalu_size;
             }
 
-            if (pkt->get_header().marker == 1) {//最后一个
+            if (pkt->get_header().marker == 1) {  // 最后一个
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.timestamp = timestamp;
                 auto video_data = std::make_unique<VIDEODATA>();
-                
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 video_data->header.composition_time = 0;
@@ -445,7 +457,7 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                 is_key = true;
             }
 
-            uint32_t s = htonl(pkt->get_payload().size() );
+            uint32_t s = htonl(pkt->get_payload().size());
             memcpy(buf, &s, 4);
             buf += 4;
             memcpy(buf, pkt->get_payload().data(), pkt->get_payload().size());
@@ -453,14 +465,16 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
 
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.timestamp = timestamp;
 
                 auto video_data = std::make_unique<VIDEODATA>();
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 video_data->header.composition_time = 0;
@@ -475,7 +489,7 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
             }
         } else if (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
             if (pkt_info.is_start_fu()) {
                 do {
@@ -485,8 +499,8 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                         }
 
                         nalu_size += pkt->get_payload().size() - 1;
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
-                        uint8_t nalu_type = (pkt_buf[0]&0xe0)|(pkt_buf[1]&0x1F);
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
+                        uint8_t nalu_type = (pkt_buf[0] & 0xe0) | (pkt_buf[1] & 0x1F);
                         memcpy(buf, &nalu_type, 1);
                         memcpy(buf + 1, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 1;
@@ -495,7 +509,7 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                         memcpy(buf, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 2;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         break;
@@ -508,21 +522,23 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 total_payload_bytes = buf - video_frame_cache_.get();
-                std::shared_ptr<FlvTag> video_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
+                std::shared_ptr<FlvTag> video_flv_tag =
+                    std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 5 + total_payload_bytes);
                 video_flv_tag->tag_header.data_size = total_payload_bytes + 5;
                 video_flv_tag->tag_header.stream_id = 0;
                 video_flv_tag->tag_header.tag_type = FlvTagHeader::VideoTag;
                 video_flv_tag->tag_header.timestamp = timestamp;
 
                 auto video_data = std::make_unique<VIDEODATA>();
-                video_data->header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+                video_data->header.frame_type =
+                    is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data->header.codec_id = VideoTagHeader::AVC;
                 video_data->header.avc_packet_type = VideoTagHeader::AVCNALU;
                 video_data->header.composition_time = 0;
-                video_data->payload = std::string_view((char*)video_frame_cache_.get(), total_payload_bytes);
+                video_data->payload = std::string_view((char *)video_frame_cache_.get(), total_payload_bytes);
 
                 video_flv_tag->tag_data = std::move(video_data);
 
@@ -532,11 +548,10 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_h264_flv_tag(uint32_t timestamp, s
                 }
                 return video_flv_tag;
             }
-        } 
+        }
     }
     return nullptr;
 }
-
 
 std::shared_ptr<FlvTag> WebRtcToFlv::generate_aac_flv_tag(uint32_t timestamp) {
     std::shared_ptr<FlvTag> audio_flv_tag = std::make_shared<FlvTag>(FLV_TAG_HEADER_BYTES + 2 + aac_bytes_);
@@ -551,7 +566,7 @@ std::shared_ptr<FlvTag> WebRtcToFlv::generate_aac_flv_tag(uint32_t timestamp) {
     audio_data->header.sound_size = AudioTagHeader::Sample_16bit;
     audio_data->header.aac_packet_type = AudioTagHeader::AACRaw;
 
-    audio_data->payload = std::string_view((char*)aac_data_, aac_bytes_);
+    audio_data->payload = std::string_view((char *)aac_data_, aac_bytes_);
     audio_flv_tag->tag_data = std::move(audio_data);
 
     auto ret = audio_flv_tag->encode();
@@ -573,10 +588,8 @@ void WebRtcToFlv::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
         AVChannelLayout in_ch_layout;
         av_channel_layout_default(&out_ch_layout, 2);
         av_channel_layout_default(&in_ch_layout, 2);
-        int ret = swr_alloc_set_opts2(&swr_context_,
-                            &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                            &in_ch_layout, AV_SAMPLE_FMT_S16, 48000, 
-                            0, NULL);
+        int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100, &in_ch_layout,
+                                      AV_SAMPLE_FMT_S16, 48000, 0, NULL);
         if (ret < 0) {
             spdlog::error("swr init failed");
             return;
@@ -593,26 +606,30 @@ void WebRtcToFlv::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
         return;
     }
 
-    int in_samples = opus_decode(opus_decoder_.get(), (uint8_t*)pkt->get_payload().data(), pkt->get_payload().size(), decoded_pcm_, 4096, 0);
+    int in_samples = opus_decode(opus_decoder_.get(), (uint8_t *)pkt->get_payload().data(),
+                                 pkt->get_payload().size(), decoded_pcm_, 4096, 0);
     if (swr_context_) {
-        // int dst_nb_samples = av_rescale_rnd(swr_get_delay(swr_context_, 48000) + in_samples, 44100, 48000, AV_ROUND_UP);
+        // int dst_nb_samples = av_rescale_rnd(swr_get_delay(swr_context_, 48000) + in_samples, 44100, 48000,
+        // AV_ROUND_UP);
         uint8_t *data_in[1];
         uint8_t *data_out[1];
-        data_in[0] = (uint8_t*)decoded_pcm_;
-        data_out[0] = (uint8_t*)resampled_pcm_;
+        data_in[0] = (uint8_t *)decoded_pcm_;
+        data_out[0] = (uint8_t *)resampled_pcm_;
         int32_t total_samples = 0;
-        int out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, (const uint8_t**)&data_in, in_samples);
+        int out_samples =
+            swr_convert(swr_context_, (uint8_t **)&data_out, 1024, (const uint8_t **)&data_in, in_samples);
         total_samples += out_samples;
-        data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
-        while ((out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, NULL, 0)) > 0) {
-            data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
+        data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
+        while ((out_samples = swr_convert(swr_context_, (uint8_t **)&data_out, 1024, NULL, 0)) > 0) {
+            data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
             total_samples += out_samples;
         }
-        
-        auto aac_bytes = aac_encoder_->encode((uint8_t*)resampled_pcm_, total_samples*2*2, aac_data_, 8192);
+
+        auto aac_bytes =
+            aac_encoder_->encode((uint8_t *)resampled_pcm_, total_samples * 2 * 2, aac_data_, 8192);
         if (aac_bytes > 0) {
             aac_bytes_ = aac_bytes;
-            auto audio_flv_tag = generate_aac_flv_tag((pkt->get_timestamp() - first_rtp_audio_ts_)/48);
+            auto audio_flv_tag = generate_aac_flv_tag((pkt->get_timestamp() - first_rtp_audio_ts_) / 48);
             if (audio_flv_tag) {
                 flv_media_source_->on_audio_packet(audio_flv_tag);
             }
@@ -620,38 +637,40 @@ void WebRtcToFlv::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
     }
 }
 
-
 void WebRtcToFlv::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
         return;
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (flv_media_source_) {
-            flv_media_source_->close();
-            flv_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtp_media_sink_) {
-            rtp_media_sink_->set_source_codec_ready_cb({});
-            rtp_media_sink_->set_audio_pkts_cb({});
-            rtp_media_sink_->set_video_pkts_cb({});
-
-            rtp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtp_media_sink_);
+            if (flv_media_source_) {
+                flv_media_source_->close();
+                flv_media_source_ = nullptr;
             }
-            rtp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtp_media_sink_) {
+                rtp_media_sink_->set_source_codec_ready_cb({});
+                rtp_media_sink_->set_audio_pkts_cb({});
+                rtp_media_sink_->set_video_pkts_cb({});
+
+                rtp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtp_media_sink_);
+                }
+                rtp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/webrtc/webrtc_to_rtmp.cpp
+++ b/live-server/bridge/webrtc/webrtc_to_rtmp.cpp
@@ -1,30 +1,35 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/redirect_error.hpp>
-
 #include "webrtc_to_rtmp.hpp"
 
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
 #include "base/thread/thread_worker.hpp"
-
-#include "core/rtp_media_sink.hpp"
-#include "core/rtmp_media_source.hpp"
-
-#include "codec/codec.hpp"
 #include "codec/aac/aac_codec.hpp"
-#include "codec/opus/opus_codec.hpp"
-#include "codec/h264/h264_codec.hpp"
 #include "codec/aac/aac_encoder.hpp"
+#include "codec/codec.hpp"
+#include "codec/h264/h264_codec.hpp"
+#include "codec/opus/opus_codec.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "core/rtp_media_sink.hpp"
+
 
 using namespace mms;
 
-WebRtcToRtmp::WebRtcToRtmp(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    source_ = std::make_shared<RtmpMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+WebRtcToRtmp::WebRtcToRtmp(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                           std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                           const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    source_ = std::make_shared<RtmpMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     rtmp_media_source_ = std::static_pointer_cast<RtmpMediaSource>(source_);
-    sink_ = std::make_shared<RtpMediaSink>(worker); 
+    sink_ = std::make_shared<RtpMediaSink>(worker);
     rtp_media_sink_ = std::static_pointer_cast<RtpMediaSink>(sink_);
-    video_frame_cache_ = std::make_unique<char[]>(1024*1024);
-    audio_frame_cache_ = std::make_unique<char[]>(1024*20);
+    video_frame_cache_ = std::make_unique<char[]>(1024 * 1024);
+    audio_frame_cache_ = std::make_unique<char[]>(1024 * 20);
     type_ = "webrtc-to-rtmp";
 }
 
@@ -39,28 +44,33 @@ WebRtcToRtmp::~WebRtcToRtmp() {
 bool WebRtcToRtmp::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(30000));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(30000));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (rtmp_media_source_->has_no_sinks_for_time(30000)) {//已经30秒没人播放了
-                spdlog::debug("close WebRtcToRtmp because no players for 30s");
-                break;
+                if (rtmp_media_source_->has_no_sinks_for_time(30000)) {  // 已经30秒没人播放了
+                    spdlog::debug("close WebRtcToRtmp because no players for 30s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec)->bool {
+    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec,
+                                                            std::shared_ptr<Codec> audio_codec) -> bool {
         video_codec_ = video_codec;
         audio_codec_ = audio_codec;
         if (video_codec_) {
@@ -72,17 +82,15 @@ bool WebRtcToRtmp::init() {
                 return false;
             }
 
-            OpusCodec *opus_codec = (OpusCodec*)audio_codec_.get();
+            OpusCodec *opus_codec = (OpusCodec *)audio_codec_.get();
             opus_decoder_ = opus_codec->create_decoder(opus_codec->getFs(), opus_codec->get_channels());
             if (!swr_context_) {
                 AVChannelLayout out_ch_layout;
                 AVChannelLayout in_ch_layout;
                 av_channel_layout_default(&out_ch_layout, 2);
                 av_channel_layout_default(&in_ch_layout, opus_codec->get_channels());
-                int ret = swr_alloc_set_opts2(&swr_context_,
-                                    &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                                    &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 
-                                    0, NULL);
+                int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
+                                              &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 0, NULL);
                 if (ret < 0) {
                     spdlog::error("swr init failed");
                     return false;
@@ -109,33 +117,35 @@ bool WebRtcToRtmp::init() {
         return generate_rtmp_headers();
     });
 
-    rtp_media_sink_->set_video_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_video_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_video_ts_ = pkts[0]->get_timestamp();
+    rtp_media_sink_->set_video_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_video_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_video_ts_ = pkts[0]->get_timestamp();
+                }
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_video_packet(pkt);
-        }
-        
-        co_return true;
-    });
-
-    rtp_media_sink_->set_audio_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_audio_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+            for (auto pkt : pkts) {
+                process_video_packet(pkt);
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_audio_packet(pkt);
-        }
-        
-        co_return true;
-    });
+            co_return true;
+        });
+
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_audio_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+                }
+            }
+
+            for (auto pkt : pkts) {
+                process_audio_packet(pkt);
+            }
+
+            co_return true;
+        });
 
     return true;
 }
@@ -194,7 +204,7 @@ bool WebRtcToRtmp::generate_metadata() {
         "width" : 1280.0
     }
     */
-    Amf0String name1; 
+    Amf0String name1;
     name1.set_value("@setDataFrame");
     Amf0String name2;
     name2.set_value("onMetaData");
@@ -205,12 +215,12 @@ bool WebRtcToRtmp::generate_metadata() {
     metadata_amf0_.set_item_value("4.1", false);
     metadata_amf0_.set_item_value("5.1", false);
     metadata_amf0_.set_item_value("7.1", false);
-    metadata_amf0_.set_item_value("audiocodecid", 10.0);//aac
+    metadata_amf0_.set_item_value("audiocodecid", 10.0);  // aac
     // 固定值
     AudioSpecificConfig audio_specific_config;
     audio_specific_config.audio_object_type = AOT_AAC_LC;
     audio_specific_config.channel_configuration = 2;
-    audio_specific_config.frequency_index = 4;//44100
+    audio_specific_config.frequency_index = 4;  // 44100
     audio_specific_config.sampling_frequency = 44100;
 
     metadata_amf0_.set_item_value("audiochannels", (double)2);
@@ -220,9 +230,9 @@ bool WebRtcToRtmp::generate_metadata() {
         metadata_amf0_.set_item_value("stereo", false);
     }
     metadata_amf0_.set_item_value("audiodatarate", 2500);
-    metadata_amf0_.set_item_value("audiosamplesize", 16.0);//好像aac是固定的16bit
+    metadata_amf0_.set_item_value("audiosamplesize", 16.0);  // 好像aac是固定的16bit
     metadata_amf0_.set_item_value("duration", 0.0);
-    metadata_amf0_.set_item_value("encoder", "mms");//todo:add version
+    metadata_amf0_.set_item_value("encoder", "mms");  // todo:add version
     metadata_amf0_.set_item_value("fileSize", 0.0);
 
     if (video_codec_->get_codec_type() == CODEC_H264) {
@@ -242,15 +252,15 @@ bool WebRtcToRtmp::generate_metadata() {
     auto total_size = name1.size() + name2.size() + metadata_amf0_.size();
     metadata_pkt_ = std::make_shared<RtmpMessage>(total_size);
     auto unuse_data = metadata_pkt_->get_unuse_data();
-    int32_t consumed1 = name1.encode((uint8_t*)unuse_data.data(), unuse_data.size());
+    int32_t consumed1 = name1.encode((uint8_t *)unuse_data.data(), unuse_data.size());
     metadata_pkt_->inc_used_bytes(consumed1);
     unuse_data = metadata_pkt_->get_unuse_data();
-    int32_t consumed2 = name2.encode((uint8_t*)unuse_data.data(), unuse_data.size());
+    int32_t consumed2 = name2.encode((uint8_t *)unuse_data.data(), unuse_data.size());
     metadata_pkt_->inc_used_bytes(consumed2);
     unuse_data = metadata_pkt_->get_unuse_data();
-    int32_t consumed3 = metadata_amf0_.encode((uint8_t*)unuse_data.data(), unuse_data.size());
+    int32_t consumed3 = metadata_amf0_.encode((uint8_t *)unuse_data.data(), unuse_data.size());
     metadata_pkt_->inc_used_bytes(consumed3);
-    
+
     metadata_pkt_->message_stream_id_ = 0;
     metadata_pkt_->chunk_stream_id_ = 18;
     metadata_pkt_->message_type_id_ = FlvTagHeader::ScriptTag;
@@ -261,9 +271,9 @@ bool WebRtcToRtmp::generate_metadata() {
 bool WebRtcToRtmp::generate_video_header() {
     if (video_codec_->get_codec_type() == CODEC_H264) {
         auto h264_codec = std::static_pointer_cast<H264Codec>(video_codec_);
-        AVCDecoderConfigurationRecord & decode_configuration_record = h264_codec->get_avc_configuration();
+        AVCDecoderConfigurationRecord &decode_configuration_record = h264_codec->get_avc_configuration();
         auto payload_size = decode_configuration_record.size();
-        video_header_ = std::make_shared<RtmpMessage>(5 + payload_size);//5字节是video tag header的大小
+        video_header_ = std::make_shared<RtmpMessage>(5 + payload_size);  // 5字节是video tag header的大小
         // rtmp头
         video_header_->message_stream_id_ = 0;
         video_header_->chunk_stream_id_ = 8;
@@ -275,9 +285,9 @@ bool WebRtcToRtmp::generate_video_header() {
         video_data.header.codec_id = VideoTagHeader::AVC;
         video_data.header.avc_packet_type = VideoTagHeader::AVCSequenceHeader;
         video_data.header.composition_time = 0;
-        
+
         auto payload = video_header_->get_unuse_data();
-        int32_t consumed1 = video_data.encode((uint8_t*)payload.data(), payload.size());
+        int32_t consumed1 = video_data.encode((uint8_t *)payload.data(), payload.size());
         if (consumed1 < 0) {
             spdlog::error("video header encode failed, consumed:{}", consumed1);
             return false;
@@ -286,18 +296,19 @@ bool WebRtcToRtmp::generate_video_header() {
         video_header_->inc_used_bytes(consumed1);
         payload = video_header_->get_unuse_data();
 
-        auto consumed2 = decode_configuration_record.encode((uint8_t*)payload.data(), payload.size());
+        auto consumed2 = decode_configuration_record.encode((uint8_t *)payload.data(), payload.size());
         if (consumed2 < 0) {
-            //spdlog::error("video configuration record encode failed");
+            // spdlog::error("video configuration record encode failed");
         } else {
-            spdlog::info("video configuration record encode succeed, consumed:{}, payload_size:{}", consumed2, payload_size);
+            spdlog::info("video configuration record encode succeed, consumed:{}, payload_size:{}", consumed2,
+                         payload_size);
         }
         video_header_->inc_used_bytes(consumed2);
         video_data.payload = payload;
         spdlog::info("video_data.payload.size()={}", video_data.payload.size());
         return true;
     }
-    
+
     return false;
 }
 
@@ -323,7 +334,7 @@ bool WebRtcToRtmp::generate_audio_header() {
             // return false;
             audio_data.header.sound_rate = AudioTagHeader::KHZ_22;
         }
-        
+
         audio_data.header.sound_size = AudioTagHeader::Sample_16bit;
         audio_data.header.aac_packet_type = AudioTagHeader::AACSequenceHeader;
 
@@ -336,7 +347,7 @@ bool WebRtcToRtmp::generate_audio_header() {
         audio_header_->timestamp_ = 0;
         // 音频头部
         auto payload = audio_header_->get_unuse_data();
-        auto consumed1 = audio_data.encode((uint8_t*)payload.data(), payload.size());
+        auto consumed1 = audio_data.encode((uint8_t *)payload.data(), payload.size());
         if (consumed1 < 0) {
             spdlog::error("audio data encode failed, consumed1:{}", consumed1);
             return false;
@@ -344,7 +355,7 @@ bool WebRtcToRtmp::generate_audio_header() {
         audio_header_->inc_used_bytes(consumed1);
         payload = audio_header_->get_unuse_data();
 
-        auto consumed2 = audio_config->encode((uint8_t*)payload.data(), payload.size());
+        auto consumed2 = audio_config->encode((uint8_t *)payload.data(), payload.size());
         if (consumed2 < 0) {
             spdlog::error("audio data encode failed, consumed2:{}", consumed2);
             return false;
@@ -353,8 +364,8 @@ bool WebRtcToRtmp::generate_audio_header() {
         audio_data.payload = payload;
         audio_header_->inc_used_bytes(consumed2);
         return true;
-    } 
-    
+    }
+
     return false;
 }
 
@@ -362,41 +373,43 @@ void WebRtcToRtmp::process_video_packet(std::shared_ptr<RtpPacket> pkt) {
     if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
         process_h264_packet(pkt);
     }
-} 
+}
 
 void WebRtcToRtmp::process_h264_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h264_nalu = rtp_h264_depacketizer_.on_packet(pkt);
     if (h264_nalu) {
         uint32_t this_timestamp = h264_nalu->get_timestamp();
-        auto rtmp_msg = generate_h264_rtmp_msg((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        auto rtmp_msg = generate_h264_rtmp_msg((this_timestamp - first_rtp_video_ts_) / 90,
+                                               h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
         if (rtmp_msg) {
             rtmp_media_source_->on_video_packet(rtmp_msg);
         }
     }
 }
 
-std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t timestamp,
+                                                                  std::shared_ptr<RtpH264NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
     int32_t total_payload_size = 0;
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
                     is_key = true;
                 }
-                
+
                 uint32_t s = htonl(nalu_size);
                 memcpy(buf, &s, 4);
                 buf += 4;
@@ -407,27 +420,28 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                 data += 2 + nalu_size;
             }
 
-            if (pkt->get_header().marker == 1) {//最后一个
+            if (pkt->get_header().marker == 1) {  // 最后一个
                 total_payload_size = buf - video_frame_cache_.get();
-                std::shared_ptr<RtmpMessage> video_msg = std::make_shared<RtmpMessage>(total_payload_size + 5);
+                std::shared_ptr<RtmpMessage> video_msg =
+                    std::make_shared<RtmpMessage>(total_payload_size + 5);
                 video_msg->message_stream_id_ = 0;
                 video_msg->chunk_stream_id_ = 8;
                 video_msg->message_type_id_ = FlvTagHeader::VideoTag;
                 video_msg->timestamp_ = timestamp;
 
                 VIDEODATA video_data;
-                
-                video_data.header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+
+                video_data.header.frame_type = is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data.header.codec_id = VideoTagHeader::AVC;
                 video_data.header.avc_packet_type = VideoTagHeader::AVCNALU;
-                video_data.header.composition_time = 0;//rtp默认不支持b帧先
+                video_data.header.composition_time = 0;  // rtp默认不支持b帧先
 
                 auto payload = video_msg->get_unuse_data();
-                video_data.payload = std::string_view((char*)payload.data() + 5, total_payload_size);
-                memcpy((char*)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
-                auto ret = video_data.encode((uint8_t*)payload.data(), total_payload_size + 5);
+                video_data.payload = std::string_view((char *)payload.data() + 5, total_payload_size);
+                memcpy((char *)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
+                auto ret = video_data.encode((uint8_t *)payload.data(), total_payload_size + 5);
                 if (ret < 0) {
-                    //spdlog::error("encode flv tag failed, code:{}", ret);
+                    // spdlog::error("encode flv tag failed, code:{}", ret);
                 }
                 video_msg->inc_used_bytes(total_payload_size + 5);
                 return video_msg;
@@ -445,7 +459,8 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
 
             if (pkt->get_header().marker == 1) {
                 total_payload_size = buf - video_frame_cache_.get();
-                std::shared_ptr<RtmpMessage> video_msg = std::make_shared<RtmpMessage>(total_payload_size + 5);
+                std::shared_ptr<RtmpMessage> video_msg =
+                    std::make_shared<RtmpMessage>(total_payload_size + 5);
                 auto payload = video_msg->get_unuse_data();
                 video_msg->message_stream_id_ = 0;
                 video_msg->chunk_stream_id_ = 8;
@@ -453,24 +468,24 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                 video_msg->timestamp_ = timestamp;
 
                 VIDEODATA video_data;
-                
-                video_data.header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+
+                video_data.header.frame_type = is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data.header.codec_id = VideoTagHeader::AVC;
                 video_data.header.avc_packet_type = VideoTagHeader::AVCNALU;
-                video_data.header.composition_time = 0;//rtp默认不支持b帧先
+                video_data.header.composition_time = 0;  // rtp默认不支持b帧先
 
-                video_data.payload = std::string_view((char*)payload.data() + 5, total_payload_size);
-                memcpy((char*)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
-                auto ret = video_data.encode((uint8_t*)payload.data(), total_payload_size + 5);
+                video_data.payload = std::string_view((char *)payload.data() + 5, total_payload_size);
+                memcpy((char *)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
+                auto ret = video_data.encode((uint8_t *)payload.data(), total_payload_size + 5);
                 if (ret < 0) {
-                    //spdlog::error("encode flv tag failed, code:{}", ret);
+                    // spdlog::error("encode flv tag failed, code:{}", ret);
                 }
                 video_msg->inc_used_bytes(total_payload_size + 5);
                 return video_msg;
             }
         } else if (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
             if (pkt_info.is_start_fu()) {
                 do {
@@ -480,8 +495,8 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                         }
 
                         nalu_size += pkt->get_payload().size() - 1;
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
-                        uint8_t nalu_type = (pkt_buf[0]&0xe0)|(pkt_buf[1]&0x1F);
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
+                        uint8_t nalu_type = (pkt_buf[0] & 0xe0) | (pkt_buf[1] & 0x1F);
                         memcpy(buf, &nalu_type, 1);
                         memcpy(buf + 1, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 1;
@@ -490,7 +505,7 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                         memcpy(buf, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 2;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         break;
@@ -503,10 +518,11 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 total_payload_size = buf - video_frame_cache_.get();
-                std::shared_ptr<RtmpMessage> video_msg = std::make_shared<RtmpMessage>(total_payload_size + 5);
+                std::shared_ptr<RtmpMessage> video_msg =
+                    std::make_shared<RtmpMessage>(total_payload_size + 5);
                 auto payload = video_msg->get_unuse_data();
                 video_msg->message_stream_id_ = 0;
                 video_msg->chunk_stream_id_ = 8;
@@ -514,26 +530,25 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_h264_rtmp_msg(uint32_t times
                 video_msg->timestamp_ = timestamp;
 
                 VIDEODATA video_data;
-                
-                video_data.header.frame_type = is_key?VideoTagHeader::KeyFrame:VideoTagHeader::InterFrame;
+
+                video_data.header.frame_type = is_key ? VideoTagHeader::KeyFrame : VideoTagHeader::InterFrame;
                 video_data.header.codec_id = VideoTagHeader::AVC;
                 video_data.header.avc_packet_type = VideoTagHeader::AVCNALU;
-                video_data.header.composition_time = 0;//rtp默认不支持b帧先
+                video_data.header.composition_time = 0;  // rtp默认不支持b帧先
 
-                video_data.payload = std::string_view((char*)payload.data() + 5, total_payload_size);
-                memcpy((char*)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
-                auto ret = video_data.encode((uint8_t*)payload.data(), total_payload_size + 5);
+                video_data.payload = std::string_view((char *)payload.data() + 5, total_payload_size);
+                memcpy((char *)payload.data() + 5, video_frame_cache_.get(), total_payload_size);
+                auto ret = video_data.encode((uint8_t *)payload.data(), total_payload_size + 5);
                 if (ret < 0) {
-                    //spdlog::error("encode rtmp video message failed, code:{}", ret);
+                    // spdlog::error("encode rtmp video message failed, code:{}", ret);
                 }
                 video_msg->inc_used_bytes(total_payload_size + 5);
                 return video_msg;
             }
-        } 
+        }
     }
     return nullptr;
 }
-
 
 std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_aac_rtmp_msg(uint32_t timestamp) {
     std::shared_ptr<RtmpMessage> audio_msg = std::make_shared<RtmpMessage>(aac_bytes_ + 2);
@@ -542,16 +557,15 @@ std::shared_ptr<RtmpMessage> WebRtcToRtmp::generate_aac_rtmp_msg(uint32_t timest
     audio_msg->message_type_id_ = FlvTagHeader::AudioTag;
     audio_msg->timestamp_ = timestamp;
 
-
     AUDIODATA audio_data;
     audio_data.header.sound_rate = AudioTagHeader::KHZ_44;
     audio_data.header.sound_format = AudioTagHeader::AAC;
     audio_data.header.sound_size = AudioTagHeader::Sample_16bit;
     audio_data.header.aac_packet_type = AudioTagHeader::AACRaw;
 
-    audio_data.payload = std::string_view((char*)audio_msg->get_using_data().data() + 2, aac_bytes_);
-    memcpy((char*)audio_msg->get_using_data().data() + 2, aac_data_, aac_bytes_);
-    auto ret = audio_data.encode((uint8_t*)audio_msg->get_using_data().data(), 2 + aac_bytes_);
+    audio_data.payload = std::string_view((char *)audio_msg->get_using_data().data() + 2, aac_bytes_);
+    memcpy((char *)audio_msg->get_using_data().data() + 2, aac_data_, aac_bytes_);
+    auto ret = audio_data.encode((uint8_t *)audio_msg->get_using_data().data(), 2 + aac_bytes_);
     if (ret < 0) {
         spdlog::error("encode audio rtmp message failed, code:{}", ret);
     }
@@ -571,10 +585,8 @@ void WebRtcToRtmp::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
         AVChannelLayout in_ch_layout;
         av_channel_layout_default(&out_ch_layout, 2);
         av_channel_layout_default(&in_ch_layout, 2);
-        int ret = swr_alloc_set_opts2(&swr_context_,
-                            &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                            &in_ch_layout, AV_SAMPLE_FMT_S16, 48000, 
-                            0, NULL);
+        int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100, &in_ch_layout,
+                                      AV_SAMPLE_FMT_S16, 48000, 0, NULL);
         if (ret < 0) {
             spdlog::error("swr init failed");
             return;
@@ -591,26 +603,30 @@ void WebRtcToRtmp::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
         return;
     }
 
-    int in_samples = opus_decode(opus_decoder_.get(), (uint8_t*)pkt->get_payload().data(), pkt->get_payload().size(), decoded_pcm_, 4096, 0);
+    int in_samples = opus_decode(opus_decoder_.get(), (uint8_t *)pkt->get_payload().data(),
+                                 pkt->get_payload().size(), decoded_pcm_, 4096, 0);
     if (swr_context_) {
-        // int dst_nb_samples = av_rescale_rnd(swr_get_delay(swr_context_, 48000) + in_samples, 44100, 48000, AV_ROUND_UP);
+        // int dst_nb_samples = av_rescale_rnd(swr_get_delay(swr_context_, 48000) + in_samples, 44100, 48000,
+        // AV_ROUND_UP);
         uint8_t *data_in[1];
         uint8_t *data_out[1];
-        data_in[0] = (uint8_t*)decoded_pcm_;
-        data_out[0] = (uint8_t*)resampled_pcm_;
+        data_in[0] = (uint8_t *)decoded_pcm_;
+        data_out[0] = (uint8_t *)resampled_pcm_;
         int32_t total_samples = 0;
-        int out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, (const uint8_t**)&data_in, in_samples);
+        int out_samples =
+            swr_convert(swr_context_, (uint8_t **)&data_out, 1024, (const uint8_t **)&data_in, in_samples);
         total_samples += out_samples;
-        data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
-        while ((out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, NULL, 0)) > 0) {
-            data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
+        data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
+        while ((out_samples = swr_convert(swr_context_, (uint8_t **)&data_out, 1024, NULL, 0)) > 0) {
+            data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
             total_samples += out_samples;
         }
-        
-        auto aac_bytes = aac_encoder_->encode((uint8_t*)resampled_pcm_, total_samples*2*2, aac_data_, 8192);
+
+        auto aac_bytes =
+            aac_encoder_->encode((uint8_t *)resampled_pcm_, total_samples * 2 * 2, aac_data_, 8192);
         if (aac_bytes > 0) {
             aac_bytes_ = aac_bytes;
-            auto audio_msg = generate_aac_rtmp_msg((pkt->get_timestamp() - first_rtp_audio_ts_)/48);
+            auto audio_msg = generate_aac_rtmp_msg((pkt->get_timestamp() - first_rtp_audio_ts_) / 48);
             if (audio_msg) {
                 rtmp_media_source_->on_audio_packet(audio_msg);
             }
@@ -618,38 +634,40 @@ void WebRtcToRtmp::process_opus_packet(std::shared_ptr<RtpPacket> pkt) {
     }
 }
 
-
 void WebRtcToRtmp::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
         return;
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (rtmp_media_source_) {
-            rtmp_media_source_->close();
-            rtmp_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtp_media_sink_) {
-            rtp_media_sink_->set_source_codec_ready_cb({});
-            rtp_media_sink_->set_video_pkts_cb({});
-            rtp_media_sink_->set_audio_pkts_cb({});
-
-            rtp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtp_media_sink_);
+            if (rtmp_media_source_) {
+                rtmp_media_source_->close();
+                rtmp_media_source_ = nullptr;
             }
-            rtp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-        co_return;
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtp_media_sink_) {
+                rtp_media_sink_->set_source_codec_ready_cb({});
+                rtp_media_sink_->set_video_pkts_cb({});
+                rtp_media_sink_->set_audio_pkts_cb({});
+
+                rtp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtp_media_sink_);
+                }
+                rtp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/bridge/webrtc/webrtc_to_ts.cpp
+++ b/live-server/bridge/webrtc/webrtc_to_ts.cpp
@@ -3,50 +3,52 @@
  * @Date: 2023-11-09 20:49:39
  * @LastEditTime: 2023-12-27 22:14:52
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\transcode\webrtc_to_ts.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
+#include "webrtc_to_ts.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
-
-#include "spdlog/spdlog.h"
-#include "webrtc_to_ts.hpp"
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/ts/ts_pat_pmt.hpp"
-#include "protocol/ts/ts_header.hpp"
-#include "protocol/ts/ts_segment.hpp"
-
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-
-#include "core/rtp_media_sink.hpp"
-#include "codec/h264/h264_codec.hpp"
-#include "codec/hevc/hevc_codec.hpp"
-#include "codec/av1/av1_codec.hpp"
-#include "codec/aac/aac_codec.hpp"
-#include "codec/aac/mpeg4_aac.hpp"
-#include "codec/aac/adts.hpp"
-#include "codec/opus/opus_codec.hpp"
-#include "codec/aac/aac_encoder.hpp"
-
-#include "base/utils/utils.h"
+#include <boost/asio/use_awaitable.hpp>
 
 #include "app/publish_app.h"
-
+#include "base/utils/utils.h"
+#include "codec/aac/aac_codec.hpp"
+#include "codec/aac/aac_encoder.hpp"
+#include "codec/aac/adts.hpp"
+#include "codec/aac/mpeg4_aac.hpp"
+#include "codec/av1/av1_codec.hpp"
+#include "codec/h264/h264_codec.hpp"
+#include "codec/hevc/hevc_codec.hpp"
+#include "codec/opus/opus_codec.hpp"
+#include "core/rtp_media_sink.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "protocol/ts/ts_header.hpp"
+#include "protocol/ts/ts_pat_pmt.hpp"
+#include "protocol/ts/ts_segment.hpp"
+#include "spdlog/spdlog.h"
 
 using namespace mms;
-WebRtcToTs::WebRtcToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app, std::weak_ptr<MediaSource> origin_source, const std::string & domain_name, const std::string & app_name, const std::string & stream_name) : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name), check_closable_timer_(worker->get_io_context()), wg_(worker) {
-    sink_ = std::make_shared<RtpMediaSink>(worker); 
+WebRtcToTs::WebRtcToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app,
+                       std::weak_ptr<MediaSource> origin_source, const std::string &domain_name,
+                       const std::string &app_name, const std::string &stream_name)
+    : MediaBridge(worker, app, origin_source, domain_name, app_name, stream_name),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
+    sink_ = std::make_shared<RtpMediaSink>(worker);
     rtp_media_sink_ = std::static_pointer_cast<RtpMediaSink>(sink_);
-    source_ = std::make_shared<TsMediaSource>(worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
+    source_ = std::make_shared<TsMediaSource>(
+        worker, std::weak_ptr<StreamSession>(std::shared_ptr<StreamSession>(nullptr)), publish_app_);
     ts_media_source_ = std::static_pointer_cast<TsMediaSource>(source_);
     video_pes_segs_.reserve(1024);
-    aac_buf_ = std::make_unique<char[]>(8192*10);
-    video_frame_cache_ = std::make_unique<char[]>(1024*1024);
-    audio_frame_cache_ = std::make_unique<char[]>(1024*20);
+    aac_buf_ = std::make_unique<char[]>(8192 * 10);
+    video_frame_cache_ = std::make_unique<char[]>(1024 * 1024);
+    audio_frame_cache_ = std::make_unique<char[]>(1024 * 20);
     spdlog::debug("create webrtc to ts");
     if (swr_context_) {
         swr_free(&swr_context_);
@@ -55,35 +57,38 @@ WebRtcToTs::WebRtcToTs(ThreadWorker *worker, std::shared_ptr<PublishApp> app, st
     type_ = "webrtc-to-ts";
 }
 
-WebRtcToTs::~WebRtcToTs() {
-
-}
+WebRtcToTs::~WebRtcToTs() {}
 
 bool WebRtcToTs::init() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(30000));//30s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                check_closable_timer_.expires_after(std::chrono::milliseconds(30000));  // 30s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            if (ts_media_source_->has_no_sinks_for_time(30000)) {//已经30秒没人播放了
-                spdlog::debug("close WebRtcToTs because no players for 30s");
-                break;
+                if (ts_media_source_->has_no_sinks_for_time(30000)) {  // 已经30秒没人播放了
+                    spdlog::debug("close WebRtcToTs because no players for 30s");
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 
-    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec, std::shared_ptr<Codec> audio_codec)->bool {
+    rtp_media_sink_->set_source_codec_ready_cb([this, self](std::shared_ptr<Codec> video_codec,
+                                                            std::shared_ptr<Codec> audio_codec) -> bool {
         video_codec_ = video_codec;
         audio_codec_ = audio_codec;
         if (video_codec_) {
@@ -94,17 +99,15 @@ bool WebRtcToTs::init() {
             if (audio_codec_->get_codec_type() != CODEC_OPUS) {
                 return false;
             }
-            OpusCodec *opus_codec = (OpusCodec*)audio_codec_.get();
+            OpusCodec *opus_codec = (OpusCodec *)audio_codec_.get();
             opus_decoder_ = opus_codec->create_decoder(opus_codec->getFs(), opus_codec->get_channels());
             if (!swr_context_) {
                 AVChannelLayout out_ch_layout;
                 AVChannelLayout in_ch_layout;
                 av_channel_layout_default(&out_ch_layout, 2);
                 av_channel_layout_default(&in_ch_layout, opus_codec->get_channels());
-                int ret = swr_alloc_set_opts2(&swr_context_,
-                                    &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                                    &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 
-                                    0, NULL);
+                int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
+                                              &in_ch_layout, AV_SAMPLE_FMT_S16, opus_codec->getFs(), 0, NULL);
                 if (ret < 0) {
                     spdlog::error("swr init failed");
                     exit(0);
@@ -137,7 +140,7 @@ bool WebRtcToTs::init() {
         }
 
         if (has_video_) {
-            PCR_PID = video_pid_; 
+            PCR_PID = video_pid_;
         } else if (has_audio_) {
             PCR_PID = audio_pid_;
         }
@@ -145,33 +148,35 @@ bool WebRtcToTs::init() {
         return true;
     });
 
-    rtp_media_sink_->set_video_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_video_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_video_ts_ = pkts[0]->get_timestamp();
+    rtp_media_sink_->set_video_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_video_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_video_ts_ = pkts[0]->get_timestamp();
+                }
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_video_packet(pkt);
-        }
-        
-        co_return true;
-    });
-
-    rtp_media_sink_->set_audio_pkts_cb([this, self](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        if (first_rtp_audio_ts_ == 0) {
-            if (pkts.size() > 0) {
-                first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+            for (auto pkt : pkts) {
+                process_video_packet(pkt);
             }
-        }
 
-        for (auto pkt : pkts) {
-            process_audio_packet(pkt, (pkt->get_timestamp() - first_rtp_audio_ts_)/48);
-        }
-        
-        co_return true;
-    });
+            co_return true;
+        });
+
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this, self](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            if (first_rtp_audio_ts_ == 0) {
+                if (pkts.size() > 0) {
+                    first_rtp_audio_ts_ = pkts[0]->get_timestamp();
+                }
+            }
+
+            for (auto pkt : pkts) {
+                process_audio_packet(pkt, (pkt->get_timestamp() - first_rtp_audio_ts_) / 48);
+            }
+
+            co_return true;
+        });
     return true;
 }
 
@@ -179,36 +184,37 @@ void WebRtcToTs::process_video_packet(std::shared_ptr<RtpPacket> pkt) {
     if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
         process_h264_packet(pkt);
     }
-} 
+}
 
 void WebRtcToTs::process_h264_packet(std::shared_ptr<RtpPacket> pkt) {
     auto h264_nalu = rtp_h264_depacketizer_.on_packet(pkt);
     if (h264_nalu) {
         int64_t this_timestamp = h264_nalu->get_timestamp();
-        generate_h264_ts((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+        generate_h264_ts((this_timestamp - first_rtp_video_ts_) / 90,
+                         h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
     }
 }
 
-void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU> &nalu) {
     bool is_key = false;
     char *buf = video_frame_cache_.get();
-    auto & pkts = nalu->get_rtp_pkts();
+    auto &pkts = nalu->get_rtp_pkts();
 
     std::string_view sps;
     std::string_view pps;
     std::list<std::string_view> nalus;
 
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
@@ -218,19 +224,19 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
                 } else if (nalu_type == H264NaluTypePPS) {
                     pps = std::string_view(buf + 4, nalu_size);
                 }
-                
+
                 uint32_t s = htonl(nalu_size);
                 memcpy(buf, &s, 4);
                 buf += 4;
                 memcpy(buf, data + 2, nalu_size);
-                nalus.emplace_back(std::string_view((char*)data+2, nalu_size));
+                nalus.emplace_back(std::string_view((char *)data + 2, nalu_size));
                 buf += nalu_size;
 
                 pos += 2 + nalu_size;
                 data += 2 + nalu_size;
             }
 
-            if (pkt->get_header().marker == 1) {//最后一个
+            if (pkt->get_header().marker == 1) {  // 最后一个
                 break;
             }
         } else if (pkt_info.is_single_nalu()) {
@@ -246,17 +252,18 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
             memcpy(buf, &s, 4);
             buf += 4;
             memcpy(buf, pkt->get_payload().data(), pkt->get_payload().size());
-            nalus.emplace_back(std::string_view((char*)pkt->get_payload().data(), pkt->get_payload().size()));
+            nalus.emplace_back(
+                std::string_view((char *)pkt->get_payload().data(), pkt->get_payload().size()));
             buf += pkt->get_payload().size();
 
             if (pkt->get_header().marker == 1) {
                 break;
-            } 
+            }
         } else if (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A) {
             int32_t nalu_size = 0;
-            int32_t *nalu_size_buf_pos = (int32_t*)buf;
+            int32_t *nalu_size_buf_pos = (int32_t *)buf;
             buf += 4;
-            char * buf_data_start = buf;
+            char *buf_data_start = buf;
             if (pkt_info.is_start_fu()) {
                 do {
                     if (pkt_info.is_start_fu()) {
@@ -265,8 +272,8 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
                         }
 
                         nalu_size += pkt->get_payload().size() - 1;
-                        const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
-                        uint8_t nalu_type = (pkt_buf[0]&0xe0)|(pkt_buf[1]&0x1F);
+                        const uint8_t *pkt_buf = (const uint8_t *)pkt->get_payload().data();
+                        uint8_t nalu_type = (pkt_buf[0] & 0xe0) | (pkt_buf[1] & 0x1F);
                         memcpy(buf, &nalu_type, 1);
                         memcpy(buf + 1, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 1;
@@ -275,7 +282,7 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
                         memcpy(buf, pkt->get_payload().data() + 2, pkt->get_payload().size() - 2);
                         buf += pkt->get_payload().size() - 2;
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         *nalu_size_buf_pos = htonl(nalu_size);
                         if (pkt_info.get_nalu_type() == H264NaluTypeSPS) {
@@ -295,25 +302,25 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-            
+
             if (pkt->get_header().marker == 1) {
                 break;
             } else {
                 spdlog::error("H264_RTP_PAYLOAD_FU_A nalu not marker");
             }
-        } 
+        }
     }
 
     if (sps.size() > 0) {
         if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
-            H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+            H264Codec *h264_codec = (H264Codec *)video_codec_.get();
             h264_codec->set_sps(std::string(sps.data(), sps.size()));
         }
     }
 
     if (pps.size() > 0) {
         if (video_codec_ && video_codec_->get_codec_type() == CODEC_H264) {
-            H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+            H264Codec *h264_codec = (H264Codec *)video_codec_.get();
             h264_codec->set_pps(std::string(pps.data(), pps.size()));
         }
     }
@@ -325,7 +332,7 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
         wait_first_key_frame_ = false;
     }
 
-    if (!curr_seg_ && !is_key) {//片段开始的帧，必须是关键帧
+    if (!curr_seg_ && !is_key) {  // 片段开始的帧，必须是关键帧
         return;
     }
 
@@ -344,16 +351,16 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
         create_pmt(pmt_seg);
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     // 判断sps,pps,aud等
     bool has_aud_nalu = false;
     bool has_sps_nalu = false;
     bool has_pps_nalu = false;
 
-    H264Codec *h264_codec = (H264Codec*)video_codec_.get();
+    H264Codec *h264_codec = (H264Codec *)video_codec_.get();
     for (auto it = nalus.begin(); it != nalus.end(); it++) {
         H264NaluType nalu_type = H264NaluType((*it->data()) & 0x1f);
         if (nalu_type == H264NaluTypeAccessUnitDelimiter) {
@@ -366,29 +373,31 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
             h264_codec->set_pps(std::string((it)->data(), (it)->size()));
         } else if (nalu_type == H264NaluTypeIDR) {
             if (!has_pps_nalu && !has_sps_nalu) {
-                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(), h264_codec->get_pps_nalu().size()));
-                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(), h264_codec->get_sps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_pps_nalu().data(),
+                                                       h264_codec->get_pps_nalu().size()));
+                it = nalus.insert(it, std::string_view(h264_codec->get_sps_nalu().data(),
+                                                       h264_codec->get_sps_nalu().size()));
                 has_pps_nalu = true;
                 has_sps_nalu = true;
             }
         }
     }
 
-    static uint8_t default_aud_nalu[] = { 0x09, 0xf0 };
-    static std::string_view aud_nalu((char*)default_aud_nalu, 2);
+    static uint8_t default_aud_nalu[] = {0x09, 0xf0};
+    static std::string_view aud_nalu((char *)default_aud_nalu, 2);
     if (!has_aud_nalu) {
         nalus.push_front(aud_nalu);
     }
     // 计算payload长度(第一个nalu头部4个字节，后面的头部只需要3字节)
-    int32_t payload_size = nalus.size()*3 + 1;//头部的总字节数
-    for (auto & nalu : nalus) {
+    int32_t payload_size = nalus.size() * 3 + 1;  // 头部的总字节数
+    for (auto &nalu : nalus) {
         payload_size += nalu.size();
     }
 
     // 添加上pes header
     // uint8_t *pes = video_pes_.get();
     char *pes = video_pes_header_;
-    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};//固定3字节头,跟annexb没什么关系
+    static char pes_start_prefix[3] = {0x00, 0x00, 0x01};  // 固定3字节头,跟annexb没什么关系
     memcpy(pes, pes_start_prefix, 3);
     pes += 3;
     // stream_id
@@ -396,40 +405,40 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
     // PES_packet_length
     uint8_t PTS_DTS_flags = 0x03;
     // if (header.composition_time == 0) {//dts = pts时，只需要dts
-        PTS_DTS_flags = 0x02;
+    PTS_DTS_flags = 0x02;
     // }
 
-    //PES_header_data_length
+    // PES_header_data_length
     uint8_t PES_header_data_length = 0;
     if (PTS_DTS_flags == 0x02) {
-        PES_header_data_length = 5;//DTS 5字节
+        PES_header_data_length = 5;  // DTS 5字节
     } else if (PTS_DTS_flags == 0x03) {
-        PES_header_data_length = 10;//PTS 5字节
+        PES_header_data_length = 10;  // PTS 5字节
     }
 
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    if (PTS_DTS_flags & 0x02) {// 填充pts
+    if (PTS_DTS_flags & 0x02) {  // 填充pts
         // uint64_t pts = (video_pkt->timestamp_ + header.composition_time)*90;
-        uint64_t pts = timestamp*90;
+        uint64_t pts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x02 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -438,13 +447,13 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((pts)&0x7fff) << 1) | 1);
+        val = int32_t((((pts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
 
-    if (PTS_DTS_flags & 0x01) {// 填充dts
-        uint64_t dts = timestamp*90;
+    if (PTS_DTS_flags & 0x01) {  // 填充dts
+        uint64_t dts = timestamp * 90;
         int32_t val = 0;
         val = int32_t(0x03 << 4 | (((dts >> 30) & 0x07) << 1) | 1);
         *pes++ = val;
@@ -453,7 +462,7 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
         *pes++ = (val >> 8);
         *pes++ = val;
 
-        val = int32_t((((dts)&0x7fff) << 1) | 1);
+        val = int32_t((((dts) & 0x7fff) << 1) | 1);
         *pes++ = (val >> 8);
         *pes++ = val;
     }
@@ -462,10 +471,10 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
     video_pes_segs_.clear();
     video_pes_segs_.emplace_back(std::string_view(video_pes_header_, video_pes_len));
 
-    static char annexb_start_code1[] = { 0x00, 0x00, 0x01 };
-    static char annexb_start_code2[] = { 0x00, 0x00, 0x00, 0x01 };    
+    static char annexb_start_code1[] = {0x00, 0x00, 0x01};
+    static char annexb_start_code2[] = {0x00, 0x00, 0x00, 0x01};
     bool first_nalu = true;
-    for (auto & nalu : nalus) {
+    for (auto &nalu : nalus) {
         if (first_nalu) {
             first_nalu = false;
             video_pes_segs_.emplace_back(std::string_view(annexb_start_code2, 4));
@@ -480,9 +489,9 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
     }
 
     pes_packet->alloc_buf(video_pes_len);
-    for (auto & seg : video_pes_segs_) {
+    for (auto &seg : video_pes_segs_) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
 
@@ -494,24 +503,23 @@ void WebRtcToTs::generate_h264_ts(int64_t timestamp, std::shared_ptr<RtpH264NALU
     ts_media_source_->on_pes_packet(pes_packet);
 }
 
-
-void WebRtcToTs::create_pat(std::string_view & data) {
-    uint8_t *buf = (uint8_t*)data.data();
+void WebRtcToTs::create_pat(std::string_view &data) {
+    uint8_t *buf = (uint8_t *)data.data();
     /*********************** ts header *********************/
-    *buf++ = 0x47;//ts header sync byte
+    *buf++ = 0x47;  // ts header sync byte
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TsPidPAT
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TsPidPAT;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
     // continuity_counter_(4b)   = 0
     *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | 00;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf++ = 0;
     uint8_t *pat_start = buf;
     // table_id
@@ -523,28 +531,32 @@ void WebRtcToTs::create_pat(std::string_view & data) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//transport_stream_id(2B) + current_next_indicator(1B) + section_number(1B) + last_section_number(1B) + crc
+    int16_t section_len = 5 + 4 + 4;  // transport_stream_id(2B) + current_next_indicator(1B) +
+                                      // section_number(1B) + last_section_number(1B) + crc
     int16_t slv = section_len & 0x0FFF;
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
-    //transport_stream_id
-    *((uint16_t*)buf) = htons(0x0001);//transport_stream_id
+    // transport_stream_id
+    *((uint16_t *)buf) = htons(0x0001);  // transport_stream_id
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf++ = cniv;
     // section_number
     *buf++ = 0;
@@ -557,26 +569,25 @@ void WebRtcToTs::create_pat(std::string_view & data) {
     v32 = (pmt_pid & 0x1FFF) | (0x07 << 13) | ((pmt_number << 16) & 0xFFFF0000);
     *((uint32_t *)buf) = htonl(v32);
     buf += 4;
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pat_start, buf - pat_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)data.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)data.data() + 188 - buf);
     return;
 }
 
-
-void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
-    uint8_t *buf = (uint8_t*)pmt_seg.data();
+void WebRtcToTs::create_pmt(std::string_view &pmt_seg) {
+    uint8_t *buf = (uint8_t *)pmt_seg.data();
     /*********************** ts header *********************/
-    *buf = 0x47;//ts header sync byte
+    *buf = 0x47;  // ts header sync byte
     buf++;
     // transport_error_indicator(1b)        0
     // payload_unit_start_indicator(1b)     1
     // transport_priority(1b)               0
     // pid(13b)                             TS_PMT_PID
     int16_t v = (0 << 15) | (1 << 14) | (0 << 13) | TS_PMT_PID;
-    (*(uint16_t*)buf) = htons(v);
+    (*(uint16_t *)buf) = htons(v);
     buf += 2;
     // transport_scrambling_control(2b) = 00
     // adaptation_field_control(2b) = payload only
@@ -584,7 +595,7 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
     *buf = (TsAdapationControlPayloadOnly << 4);
     buf++;
     /********************** psi header *********************/
-    //payload_unit_start_indicator = 1, pointer_field = 0
+    // payload_unit_start_indicator = 1, pointer_field = 0
     *buf = 0;
     buf++;
     uint8_t *pmt_start = buf;
@@ -598,15 +609,19 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
     // int8_t const0_value; //1bit
     // // reverved value, must be '1'
     // int8_t const1_value; //2bits
-    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the number
-    // // of bytes of the section, starting immediately following the section_length field, and including the CRC. The value in this
+    // // This is a 12-bit field, the first two bits of which shall be '00'. The remaining 10 bits specify the
+    // number
+    // // of bytes of the section, starting immediately following the section_length field, and including the
+    // CRC. The value in this
     // // field shall not exceed 1021 (0x3FD).
     // uint16_t section_length; //12bits
     // section_length = psi_size + 4;
-    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number + last_section_number + program_number
-    
+    // psi_size = transport_stream_id + reserved + version_number + current_next_indicator + section_number +
+    // last_section_number + program_number
+
     // section_length
-    int16_t section_len = 5 + 4 + 4;//5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
+    int16_t section_len =
+        5 + 4 + 4;  // 5 + PCR_PID(2B) + program_info_length(2B) + VIDEO(5B) + AUDIO(5B) + crc32(4B)
     if (has_video_) {
         section_len += 5;
     }
@@ -618,16 +633,16 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
     slv |= (1 << 15) & 0x8000;
     slv |= (0 << 14) & 0x4000;
     slv |= (3 << 12) & 0x3000;
-    *((uint16_t*)buf) = htons(slv);
+    *((uint16_t *)buf) = htons(slv);
     buf += 2;
 
     // program number
-    *((uint16_t*)buf) = htons(TS_PMT_NUMBER);//program number
+    *((uint16_t *)buf) = htons(TS_PMT_NUMBER);  // program number
     buf += 2;
     // 1B
-    int8_t cniv = 0x01;//current_next_indicator 1b 1
-    cniv |= (0 << 1) & 0x3E;//version_number 5b 00000
-    cniv |= (3 << 6) & 0xC0;//reserved 2b 11
+    int8_t cniv = 0x01;       // current_next_indicator 1b 1
+    cniv |= (0 << 1) & 0x3E;  // version_number 5b 00000
+    cniv |= (3 << 6) & 0xC0;  // reserved 2b 11
     *buf = cniv;
     buf++;
     // section_number
@@ -636,30 +651,30 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
     // last_section_number
     *buf = 0;
     buf++;
-    // reserved 3 bslbf 
+    // reserved 3 bslbf
     // PCR_PID 13 uimsbf
     // 2B
     int16_t ppv = PCR_PID & 0x1FFF;
     ppv |= (7 << 13) & 0xE000;
-    *((uint16_t*)buf) = htons(ppv);
+    *((uint16_t *)buf) = htons(ppv);
     buf += 2;
-    // reserved 4 bslbf 
+    // reserved 4 bslbf
     // program_info_length 12 0
     // 2B
     int16_t pilv = 0 & 0xFFF;
     pilv |= (0xf << 12) & 0xF000;
-    *((uint16_t*)buf) = htons(pilv);
+    *((uint16_t *)buf) = htons(pilv);
     buf += 2;
-    // for (i = 0; i < N1; i++) { 
-    //     stream_type 8 uimsbf 
-    //     reserved 3 bslbf 
-    //     elementary_PID 13 uimsbf 
-        
-    //     reserved 4 bslbf 
-    //     ES_info_length 12 uimsbf 
-    //     for (i = 0; i < N2; i++) { 
-    //         descriptor() 
-    //     } 
+    // for (i = 0; i < N1; i++) {
+    //     stream_type 8 uimsbf
+    //     reserved 3 bslbf
+    //     elementary_PID 13 uimsbf
+
+    //     reserved 4 bslbf
+    //     ES_info_length 12 uimsbf
+    //     for (i = 0; i < N2; i++) {
+    //         descriptor()
+    //     }
     // }
 
     if (has_audio_) {
@@ -667,11 +682,11 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = audio_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
@@ -680,19 +695,19 @@ void WebRtcToTs::create_pmt(std::string_view & pmt_seg) {
         buf++;
         int16_t epv = video_pid_ & 0x1FFF;
         epv |= (0x7 << 13) & 0xE000;
-        *((uint16_t*)buf) = htons(epv);
+        *((uint16_t *)buf) = htons(epv);
         buf += 2;
         int16_t eilv = 0 & 0x0FFF;
         eilv |= (0xf << 12) & 0xF000;
-        *((uint16_t*)buf) = htons(eilv);
+        *((uint16_t *)buf) = htons(eilv);
         buf += 2;
     }
 
-    //crc32
+    // crc32
     uint32_t crc32 = Utils::calc_mpeg_ts_crc32(pmt_start, buf - pmt_start);
     *(uint32_t *)buf = htonl(crc32);
     buf += 4;
-    memset(buf, 0xFF, (uint8_t*)pmt_seg.data() + 188 - buf);
+    memset(buf, 0xFF, (uint8_t *)pmt_seg.data() + 188 - buf);
     return;
 }
 
@@ -707,11 +722,11 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
 
         uint8_t payload_unit_start_indicator = 0;
-        if (left_count == pes_len) {// 第一个ts切片，置上标志位
+        if (left_count == pes_len) {  // 第一个ts切片，置上标志位
             payload_unit_start_indicator = 1;
         }
         // transport_error_indicator(1b)        0
@@ -719,12 +734,11 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
         // transport_priority(1b)               0
         // pid(13b)                             TsPidPAT
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | video_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
 
-        
         bool write_pcr = false;
-        if (left_count == pes_len) {// 第一个切片
+        if (left_count == pes_len) {  // 第一个切片
             if (PCR_PID == video_pid_ && is_key) {
                 write_pcr = true;
             }
@@ -739,16 +753,17 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
         // adaptation_field_control(2b) = payload only
         // continuity_counter_(4b)   = 0
         if (write_pcr || write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[video_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[video_pid_] & 0x0f);
         }
         continuity_counter_[video_pid_]++;
 
         int adaptation_field_total_length = 0;
         if (write_pcr) {
             // adaptation_field_length
-            adaptation_field_total_length = 8;// adaptation_field_length(1) + flags(1) + PCR(6) = 8
+            adaptation_field_total_length = 8;  // adaptation_field_length(1) + flags(1) + PCR(6) = 8
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -759,14 +774,14 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
             if (staffing_count > 0) {
                 adaptation_field_total_length += staffing_count;
             }
-            int adaptation_field_length = adaptation_field_total_length - 1;// 需要减掉自己的1字节
+            int adaptation_field_length = adaptation_field_total_length - 1;  // 需要减掉自己的1字节
             *buf++ = adaptation_field_length;
-            *buf++ = 0x10;// (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
-            int64_t pcrv = (0) & 0x1ff;//program_clock_reference_base
-            pcrv |= (0x3f << 9) & 0x7E00;//reserved
+            *buf++ = 0x10;                 // (PCR_flag << 4) & 0x10; 有pcr，直接写成0x10
+            int64_t pcrv = (0) & 0x1ff;    // program_clock_reference_base
+            pcrv |= (0x3f << 9) & 0x7E00;  // reserved
             pcrv |= (pes_packet->pes_header.dts << 15) & 0xFFFFFFFF8000LL;
 
-            char *pp = (char*)&pcrv;
+            char *pp = (char *)&pcrv;
             *buf++ = pp[5];
             *buf++ = pp[4];
             *buf++ = pp[3];
@@ -780,7 +795,7 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
         }
 
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -793,7 +808,7 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -808,12 +823,12 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, video_pes_segs_[curr_pes_seg_index].data(), left_consume);
                 video_pes_segs_[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -825,7 +840,6 @@ void WebRtcToTs::create_video_ts(std::shared_ptr<PESPacket> pes_packet, int32_t 
     }
     pes_packet->ts_bytes = ts_total_bytes;
 }
-
 
 void WebRtcToTs::process_audio_packet(std::shared_ptr<RtpPacket> pkt, int64_t timestamp) {
     if (audio_codec_ && audio_codec_->get_codec_type() == CODEC_OPUS) {
@@ -839,10 +853,8 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
         AVChannelLayout in_ch_layout;
         av_channel_layout_default(&out_ch_layout, 2);
         av_channel_layout_default(&in_ch_layout, 2);
-        int ret = swr_alloc_set_opts2(&swr_context_,
-                            &out_ch_layout, AV_SAMPLE_FMT_S16, 44100,
-                            &in_ch_layout, AV_SAMPLE_FMT_S16, 48000, 
-                            0, NULL);
+        int ret = swr_alloc_set_opts2(&swr_context_, &out_ch_layout, AV_SAMPLE_FMT_S16, 44100, &in_ch_layout,
+                                      AV_SAMPLE_FMT_S16, 48000, 0, NULL);
         if (ret < 0) {
             spdlog::error("swr init failed");
             return;
@@ -861,22 +873,24 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
 
     auto decoder = opus_decoder_.get();
     int32_t aac_bytes = 0;
-    int in_samples = opus_decode(decoder, (uint8_t*)pkt->get_payload().data(), pkt->get_payload().size(), decoded_pcm_, 4096, 0);
+    int in_samples = opus_decode(decoder, (uint8_t *)pkt->get_payload().data(), pkt->get_payload().size(),
+                                 decoded_pcm_, 4096, 0);
     if (swr_context_) {
         uint8_t *data_in[1];
         uint8_t *data_out[1];
-        data_in[0] = (uint8_t*)decoded_pcm_;
-        data_out[0] = (uint8_t*)resampled_pcm_;
+        data_in[0] = (uint8_t *)decoded_pcm_;
+        data_out[0] = (uint8_t *)resampled_pcm_;
         int32_t total_samples = 0;
-        int out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, (const uint8_t**)&data_in, in_samples);
+        int out_samples =
+            swr_convert(swr_context_, (uint8_t **)&data_out, 1024, (const uint8_t **)&data_in, in_samples);
         total_samples += out_samples;
-        data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
-        while ((out_samples = swr_convert(swr_context_, (uint8_t**)&data_out, 1024, NULL, 0)) > 0) {
-            data_out[0] = (uint8_t*)resampled_pcm_ + total_samples*2*2;
+        data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
+        while ((out_samples = swr_convert(swr_context_, (uint8_t **)&data_out, 1024, NULL, 0)) > 0) {
+            data_out[0] = (uint8_t *)resampled_pcm_ + total_samples * 2 * 2;
             total_samples += out_samples;
         }
-        
-        aac_bytes = aac_encoder_->encode((uint8_t*)resampled_pcm_, total_samples*2*2, aac_data_, 8192);
+
+        aac_bytes = aac_encoder_->encode((uint8_t *)resampled_pcm_, total_samples * 2 * 2, aac_data_, 8192);
     }
 
     if (aac_bytes <= 0) {
@@ -901,13 +915,13 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
 
     int32_t audio_payload_size = aac_bytes;
     int32_t frame_length = 7 + audio_payload_size;
-    auto & adts_header = adts_headers_[adts_header_index_];
+    auto &adts_header = adts_headers_[adts_header_index_];
     uint8_t aac_profile = AdtsAacProfileLC;
     adts_header.data[0] = 0xff;
     adts_header.data[1] = 0xf9;
     adts_header.data[2] = (aac_profile << 6) & 0xc0;
     // sampling_frequency_index 4bits
-    adts_header.data[2] |= (4 << 2) & 0x3c;//44100
+    adts_header.data[2] |= (4 << 2) & 0x3c;  // 44100
     // channel_configuration 3bits(2 channel)
     adts_header.data[2] |= (2 >> 2) & 0x01;
     adts_header.data[3] = (2 << 6) & 0xc0;
@@ -921,11 +935,11 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
     adts_header.data[6] = 0xfc;
     // uint8_t adts_header[7] = { 0xff, 0xf9, 0x00, 0x00, 0x00, 0x0f, 0xfc };
     adts_header_index_++;
-    
+
     audio_buf_.audio_pes_segs.emplace_back(std::string_view(adts_header.data, 7));
     audio_buf_.audio_pes_segs.emplace_back(std::string_view(aac_payload, audio_payload_size));
     audio_buf_.audio_pes_len += (7 + audio_payload_size);
-    if (audio_buf_.audio_pes_len < 1400) {//至少1400字节，再一起送切片
+    if (audio_buf_.audio_pes_len < 1400) {  // 至少1400字节，再一起送切片
         return;
     }
 
@@ -937,9 +951,9 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
         create_pmt(pmt_seg);
     }
 
-    auto pes_packet = std::make_shared<PESPacket>();// pes_packet;
-    auto & pes_header = pes_packet->pes_header;
-    memset((void*)&pes_header, 0, sizeof(pes_header));
+    auto pes_packet = std::make_shared<PESPacket>();  // pes_packet;
+    auto &pes_header = pes_packet->pes_header;
+    memset((void *)&pes_header, 0, sizeof(pes_header));
 
     char *pes = audio_pes_header_;
     static char pes_start_prefix[3] = {0x00, 0x00, 0x01};
@@ -948,31 +962,31 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
     // stream_id
     *pes++ = TsPESStreamIdAudioCommon;
     uint8_t PTS_DTS_flags = 0x02;
-    uint8_t PES_header_data_length = 5;//只有pts
+    uint8_t PES_header_data_length = 5;  // 只有pts
     // int32_t payload_size = 7 + payload.size() - header_consumed;//adts header + payload
     int32_t payload_size = audio_buf_.audio_pes_len;
     uint32_t PES_packet_length_tmp = 3 + PES_header_data_length + payload_size;
-    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff?0:PES_packet_length_tmp;
-    *((uint16_t*)pes) = htons(PES_packet_length);
+    uint16_t PES_packet_length = PES_packet_length_tmp > 0xffff ? 0 : PES_packet_length_tmp;
+    *((uint16_t *)pes) = htons(PES_packet_length);
     pes += 2;
     // 10' 2 bslbf
-    // PES_scrambling_control 2 bslbf 
-    // PES_priority 1 bslbf 
-    // data_alignment_indicator 1 bslbf 
-    // copyright 1 bslbf 
-    // original_or_copy 1 bslbf 
+    // PES_scrambling_control 2 bslbf
+    // PES_priority 1 bslbf
+    // data_alignment_indicator 1 bslbf
+    // copyright 1 bslbf
+    // original_or_copy 1 bslbf
     *pes++ = 0x80;
-    // PTS_DTS_flags 2 bslbf 
-    // ESCR_flag 1 bslbf 
-    // ES_rate_flag 1 bslbf 
-    // DSM_trick_mode_flag 1 bslbf 
-    // additional_copy_info_flag 1 bslbf 
-    // PES_CRC_flag 1 bslbf 
+    // PTS_DTS_flags 2 bslbf
+    // ESCR_flag 1 bslbf
+    // ES_rate_flag 1 bslbf
+    // DSM_trick_mode_flag 1 bslbf
+    // additional_copy_info_flag 1 bslbf
+    // PES_CRC_flag 1 bslbf
     // PES_extension_flag
     *pes++ = PTS_DTS_flags << 6;
     *pes++ = PES_header_data_length;
-    //audio pts
-    uint64_t pts = audio_buf_.timestamp*90;
+    // audio pts
+    uint64_t pts = audio_buf_.timestamp * 90;
     int32_t val = 0;
     val = int32_t(0x03 << 4 | (((pts >> 30) & 0x07) << 1) | 1);
     *pes++ = val;
@@ -981,10 +995,10 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
     *pes++ = (val >> 8);
     *pes++ = val;
 
-    val = int32_t((((pts)&0x7fff) << 1) | 1);
+    val = int32_t((((pts) & 0x7fff) << 1) | 1);
     *pes++ = (val >> 8);
     *pes++ = val;
-    
+
     int32_t pes_header_len = pes - audio_pes_header_;
     audio_buf_.audio_pes_len += pes_header_len;
     audio_buf_.audio_pes_segs[0] = std::string_view(audio_pes_header_, pes_header_len);
@@ -992,10 +1006,10 @@ void WebRtcToTs::process_opus_packet(std::shared_ptr<RtpPacket> pkt, int64_t tim
     pes_packet->alloc_buf(audio_buf_.audio_pes_len);
     for (auto seg : audio_buf_.audio_pes_segs) {
         auto unuse_payload = pes_packet->get_unuse_data();
-        memcpy((void*)unuse_payload.data(), seg.data(), seg.size());
+        memcpy((void *)unuse_payload.data(), seg.data(), seg.size());
         pes_packet->inc_used_bytes(seg.size());
     }
-    
+
     create_audio_ts(pes_packet);
     curr_seg_->update_audio_pts(audio_buf_.timestamp);
     audio_buf_.clear();
@@ -1015,8 +1029,8 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         int32_t space_left = 184;
         std::string_view ts_seg = curr_seg_->alloc_ts_packet();
         ts_total_bytes += 188;
-        uint8_t *buf = (uint8_t*)ts_seg.data();
-        *buf++ = 0x47;//ts header sync byte
+        uint8_t *buf = (uint8_t *)ts_seg.data();
+        *buf++ = 0x47;  // ts header sync byte
         // transport_error_indicator(1b)        0
         // payload_unit_start_indicator(1b)     1
         // transport_priority(1b)               0
@@ -1026,7 +1040,7 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             payload_unit_start_indicator = 1;
         }
         int16_t v = (0 << 15) | (payload_unit_start_indicator << 14) | (0 << 13) | audio_pid_;
-        (*(uint16_t*)buf) = htons(v);
+        (*(uint16_t *)buf) = htons(v);
         buf += 2;
         // transport_scrambling_control(2b) = 00
         // adaptation_field_control(2b) = payload only
@@ -1037,15 +1051,16 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
         }
 
         if (write_padding) {
-            *buf++ = (00 << 6 ) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ = (00 << 6) | (TsAdapationControlBoth << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         } else {
-            *buf++ = (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
+            *buf++ =
+                (00 << 6) | (TsAdapationControlPayloadOnly << 4) | (continuity_counter_[audio_pid_] & 0x0f);
         }
 
         continuity_counter_[audio_pid_]++;
         int adaptation_field_total_length = 0;
         if (write_padding) {
-            adaptation_field_total_length = 2;// adaptation_field_length + flags = 2
+            adaptation_field_total_length = 2;  // adaptation_field_length + flags = 2
             int staffing_count = 0;
             if ((4 + adaptation_field_total_length + left_count) <= 188) {
                 staffing_count = 188 - (4 + adaptation_field_total_length + left_count);
@@ -1058,7 +1073,7 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
             }
             int adaptation_field_length = adaptation_field_total_length - 1;
             *buf++ = adaptation_field_length;
-            *buf++ = 0x00;//(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
+            *buf++ = 0x00;  //(PCR_flag << 4) & 0x10;   末尾的，不需要pcr
             memset(buf, 0xff, staffing_count);
             buf += staffing_count;
         }
@@ -1074,12 +1089,12 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
                 curr_pes_seg_index++;
                 left_consume -= curr_seg_size;
                 buff_off += curr_seg_size;
-            } else if (curr_seg_size == left_consume) {// 可以覆盖
+            } else if (curr_seg_size == left_consume) {  // 可以覆盖
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 curr_pes_seg_index++;
                 buff_off += left_consume;
                 left_consume = 0;
-            } else {//curr_seg_size > left_consume
+            } else {  // curr_seg_size > left_consume
                 memcpy(buf + buff_off, audio_buf_.audio_pes_segs[curr_pes_seg_index].data(), left_consume);
                 audio_buf_.audio_pes_segs[curr_pes_seg_index].remove_prefix(left_consume);
                 left_consume = 0;
@@ -1091,9 +1106,7 @@ void WebRtcToTs::create_audio_ts(std::shared_ptr<PESPacket> pes_packet) {
     pes_packet->ts_bytes = ts_total_bytes;
 }
 
-void WebRtcToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) {
-    ts_media_source_->on_ts_segment(seg);
-}
+void WebRtcToTs::on_ts_segment(std::shared_ptr<TsSegment> seg) { ts_media_source_->on_ts_segment(seg); }
 
 void WebRtcToTs::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
@@ -1101,29 +1114,32 @@ void WebRtcToTs::close() {
     }
 
     auto self(shared_from_this());
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        check_closable_timer_.cancel();
-        co_await wg_.wait();
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            check_closable_timer_.cancel();
+            co_await wg_.wait();
 
-        if (ts_media_source_) {
-            ts_media_source_->close();
-            ts_media_source_ = nullptr;
-        }
-
-        auto origin_source = origin_source_.lock();
-        if (rtp_media_sink_) {
-            rtp_media_sink_->set_source_codec_ready_cb({});
-            rtp_media_sink_->set_video_pkts_cb({});
-            rtp_media_sink_->set_audio_pkts_cb({});
-            rtp_media_sink_->close();
-            if (origin_source) {
-                origin_source->remove_media_sink(rtp_media_sink_);
+            if (ts_media_source_) {
+                ts_media_source_->close();
+                ts_media_source_ = nullptr;
             }
-            rtp_media_sink_ = nullptr;
-        }
 
-        if (origin_source) {
-            origin_source->remove_bridge(shared_from_this());
-        }
-    }, boost::asio::detached);
+            auto origin_source = origin_source_.lock();
+            if (rtp_media_sink_) {
+                rtp_media_sink_->set_source_codec_ready_cb({});
+                rtp_media_sink_->set_video_pkts_cb({});
+                rtp_media_sink_->set_audio_pkts_cb({});
+                rtp_media_sink_->close();
+                if (origin_source) {
+                    origin_source->remove_media_sink(rtp_media_sink_);
+                }
+                rtp_media_sink_ = nullptr;
+            }
+
+            if (origin_source) {
+                origin_source->remove_bridge(shared_from_this());
+            }
+        },
+        boost::asio::detached);
 }

--- a/live-server/client/http/http_flv_client_session.cpp
+++ b/live-server/client/http/http_flv_client_session.cpp
@@ -1,42 +1,37 @@
+#include "http_flv_client_session.hpp"
+
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "http_flv_client_session.hpp"
-#include "http_client.hpp"
-
-#include "base/sequence_pkt_buf.hpp"
-#include "base/utils/utils.h"
-#include "base/thread/thread_worker.hpp"
-
-#include "core/rtmp_media_source.hpp"
-#include "core/flv_media_source.hpp"
-#include "core/source_manager.hpp"
-#include "core/media_event.hpp"
-
-#include "protocol/rtmp/flv/flv_define.hpp"
-#include "protocol/rtmp/flv/flv_tag.hpp"
-#include "protocol/http/http_response.hpp"
-#include "protocol/http/http_request.hpp"
-
-#include "service/dns/dns_service.hpp"
-#include "config/cdn/origin_pull_config.h"
-
-#include "config/app_config.h"
 #include "app/app.h"
 #include "app/publish_app.h"
+#include "base/sequence_pkt_buf.hpp"
+#include "base/thread/thread_worker.hpp"
+#include "base/utils/utils.h"
+#include "config/app_config.h"
+#include "config/cdn/origin_pull_config.h"
+#include "core/flv_media_source.hpp"
+#include "core/media_event.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "http_client.hpp"
 #include "log/log.h"
+#include "protocol/http/http_request.hpp"
+#include "protocol/http/http_response.hpp"
+#include "protocol/rtmp/flv/flv_define.hpp"
+#include "protocol/rtmp/flv/flv_tag.hpp"
+#include "service/dns/dns_service.hpp"
+
 
 using namespace mms;
 
-
-HttpFlvClientSession::HttpFlvClientSession(std::shared_ptr<PublishApp> app, 
-                                           ThreadWorker *worker, 
-                                           const std::string & domain_name, const std::string & app_name , const std::string & stream_name) : 
-                                           StreamSession(worker), flv_tags_(2048), check_closable_timer_(worker->get_io_context()), 
-                                           wg_(worker) {
+HttpFlvClientSession::HttpFlvClientSession(std::shared_ptr<PublishApp> app, ThreadWorker *worker,
+                                           const std::string &domain_name, const std::string &app_name,
+                                           const std::string &stream_name)
+    : StreamSession(worker), flv_tags_(2048), check_closable_timer_(worker->get_io_context()), wg_(worker) {
     set_app(app);
     set_session_type("flv");
     set_session_info(domain_name, app_name, stream_name);
@@ -46,229 +41,241 @@ HttpFlvClientSession::~HttpFlvClientSession() {
     CORE_DEBUG("destroy HttpFlvClientSession:{}", get_session_name());
 }
 
-void HttpFlvClientSession::set_url(const std::string & url) {
-    url_ = url;
-}
+void HttpFlvClientSession::set_url(const std::string &url) { url_ = url; }
 
 void HttpFlvClientSession::set_pull_config(std::shared_ptr<OriginPullConfig> pull_config) {
     pull_config_ = pull_config;
 }
 
-std::shared_ptr<FlvMediaSource> HttpFlvClientSession::get_flv_media_source() {
-    return flv_media_source_;
-}
+std::shared_ptr<FlvMediaSource> HttpFlvClientSession::get_flv_media_source() { return flv_media_source_; }
 
 void HttpFlvClientSession::service() {
     auto self(std::static_pointer_cast<HttpFlvClientSession>(shared_from_this()));
     auto publish_app = std::static_pointer_cast<PublishApp>(app_);
-    auto media_source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
+    auto media_source =
+        SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
     if (!media_source) {
-        media_source = std::make_shared<FlvMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
+        media_source =
+            std::make_shared<FlvMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
     }
 
     if (media_source->get_media_type() != "flv") {
-        CORE_ERROR("source:{} is already exist and type is:{}", get_session_name(), media_source->get_media_type());
+        CORE_ERROR("source:{} is already exist and type is:{}", get_session_name(),
+                   media_source->get_media_type());
         return;
     }
 
     flv_media_source_ = std::static_pointer_cast<FlvMediaSource>(media_source);
     flv_media_source_->set_source_info(get_domain_name(), get_app_name(), get_stream_name());
     flv_media_source_->set_session(self);
-    if (!SourceManager::get_instance().add_source(get_domain_name(), 
-                                                  get_app_name(),
-                                                  get_stream_name(),
+    if (!SourceManager::get_instance().add_source(get_domain_name(), get_app_name(), get_stream_name(),
                                                   flv_media_source_)) {
         CORE_ERROR("source:{} is already exist", get_session_name());
         return;
     }
 
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(pull_config_->no_players_timeout_ms()/2));//10s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                check_closable_timer_.expires_after(
+                    std::chrono::milliseconds(pull_config_->no_players_timeout_ms() / 2));  // 10s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
+
+                if (!flv_media_source_) {
+                    break;
+                }
+
+                if (flv_media_source_->has_no_sinks_for_time(
+                        pull_config_->no_players_timeout_ms())) {  // 已经10秒没人播放了
+                    CORE_DEBUG("close HttpFlvClientSession:{} because no players for {}s", get_session_name(),
+                               pull_config_->no_players_timeout_ms() / 1000);
+                    break;
+                }
             }
-
-            if (!flv_media_source_) {
-                break;
-            }
-
-            if (flv_media_source_->has_no_sinks_for_time(pull_config_->no_players_timeout_ms())) {//已经10秒没人播放了
-                CORE_DEBUG("close HttpFlvClientSession:{} because no players for {}s", get_session_name(), pull_config_->no_players_timeout_ms()/1000);
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
-    
-    wg_.add(1);
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        // 根据url获取信息
-        std::string protocol;
-        std::string domain;
-        uint16_t port;
-        std::string path;
-        std::unordered_map<std::string, std::string> params;
-
-        if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {//todo:add log
-            CORE_ERROR("HttpFlvClientSession:{} parse url:{} failed", get_session_name(), url_);
             co_return;
-        }
-        // 解析app名称
-        std::vector<std::string> vs;
-        boost::split(vs, path, boost::is_any_of("/"));
-        if (vs.size() <= 2) {
-            co_return;
-        }
-
-        //获取域名ip
-        auto ip = DnsService::get_instance().get_ip(domain);
-        if (!ip) {
-            CORE_ERROR("HttpFlvClientSession:{} could not find ip for:%s", get_session_name(), domain.c_str());
-            flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
-            co_return;
-        }
-        auto & server_ip = ip.value();
-        if (protocol == "http") {
-            http_client_ = std::make_shared<HttpClient>(get_worker(), false);
-        } else if (protocol == "https") {
-            http_client_ = std::make_shared<HttpClient>(get_worker(), true);
-        } else {
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
             close();
-            co_return;
-        }
-        
-        HttpRequest http_req;
-        http_req.set_method(GET);
-        http_req.set_path(path);
-        http_req.set_query_params(params);
-        http_req.set_version("1.1");
-        http_req.add_header("Content-Length", "0");
-        http_req.add_header("Accept", "*/*");
-        http_req.add_header("Connection", "close"); // 表示发送完就结束，不是默认的keep-alive
-        http_req.add_header("Host", domain);
-        http_req.add_header("User-Agent", "mms-server");
-        http_client_->set_buffer_size(1024*1024);
-        auto resp = co_await http_client_->do_req(server_ip, port, http_req);
-        if (!resp) {
-            CORE_ERROR("connect to ip:{} failed", server_ip);
-            flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
-            co_return;
-        }
+        });
 
-        bool ret = co_await resp->recv_http_header();
-        if (!ret) {
-            CORE_WARN("recv http header from ip:{} failed", server_ip);
-            flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
-            co_return;
-        }
+    wg_.add(1);
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            // 根据url获取信息
+            std::string protocol;
+            std::string domain;
+            uint16_t port;
+            std::string path;
+            std::unordered_map<std::string, std::string> params;
 
-        if (resp->get_status_code() == 302) {
-            http_client_->close();
-            http_client_.reset();
-            auto location = resp->get_header("Location");
-            CORE_DEBUG("HttpFlvClientSession:{} http response 302, redirect to:", get_session_name(), location.c_str());
-            if (!Utils::parse_url(location, protocol, domain, port, path, params)) {//todo:add log
-                CORE_ERROR("parse http url failed, url:%s", location.c_str());
-                flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
+            if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {  // todo:add log
+                CORE_ERROR("HttpFlvClientSession:{} parse url:{} failed", get_session_name(), url_);
                 co_return;
             }
-            //获取域名ip
+            // 解析app名称
+            std::vector<std::string> vs;
+            boost::split(vs, path, boost::is_any_of("/"));
+            if (vs.size() <= 2) {
+                co_return;
+            }
+
+            // 获取域名ip
             auto ip = DnsService::get_instance().get_ip(domain);
             if (!ip) {
-                CORE_ERROR("could not find ip for:%s", domain.c_str());
+                CORE_ERROR("HttpFlvClientSession:{} could not find ip for:%s", get_session_name(),
+                           domain.c_str());
                 flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
                 co_return;
             }
-            
-            http_client_ = std::make_shared<HttpClient>(get_worker());
-            auto & server_ip = ip.value();
-
-            HttpRequest redirect_http_req;
-            redirect_http_req.set_method(GET);
-            redirect_http_req.set_path(path);
-            redirect_http_req.set_query_params(params);
-            redirect_http_req.set_version("1.1");
-            redirect_http_req.add_header("Content-Length", "0");
-            redirect_http_req.add_header("Accept", "*/*");
-            redirect_http_req.add_header("Connection", "close"); // 表示发送完就结束，不是默认的keep-alive
-            redirect_http_req.add_header("Host", domain);
-            redirect_http_req.add_header("User-Agent", "mms-server");
-            http_client_->set_buffer_size(1024*1024);
-            resp = co_await http_client_->do_req(server_ip, port, redirect_http_req);
-        }
-
-        if (resp->get_status_code() != 200) {//todo: notify media event
-            if (resp->get_status_code() == 403) {
-                flv_media_source_->set_status(E_SOURCE_STATUS_FORBIDDEN);
-            } else if (resp->get_status_code() == 404) {
-                flv_media_source_->set_status(E_SOURCE_STATUS_NOT_FOUND);
+            auto &server_ip = ip.value();
+            if (protocol == "http") {
+                http_client_ = std::make_shared<HttpClient>(get_worker(), false);
+            } else if (protocol == "https") {
+                http_client_ = std::make_shared<HttpClient>(get_worker(), true);
+            } else {
+                close();
+                co_return;
             }
-            CORE_ERROR("http code error, code:{}", resp->get_status_code());
-            co_return;
-        }
 
-        co_await cycle_pull_flv_tag(resp);
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        ((void)exp);
-        wg_.done();
-        close();
-    });
+            HttpRequest http_req;
+            http_req.set_method(GET);
+            http_req.set_path(path);
+            http_req.set_query_params(params);
+            http_req.set_version("1.1");
+            http_req.add_header("Content-Length", "0");
+            http_req.add_header("Accept", "*/*");
+            http_req.add_header("Connection", "close");  // 表示发送完就结束，不是默认的keep-alive
+            http_req.add_header("Host", domain);
+            http_req.add_header("User-Agent", "mms-server");
+            http_client_->set_buffer_size(1024 * 1024);
+            auto resp = co_await http_client_->do_req(server_ip, port, http_req);
+            if (!resp) {
+                CORE_ERROR("connect to ip:{} failed", server_ip);
+                flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
+                co_return;
+            }
+
+            bool ret = co_await resp->recv_http_header();
+            if (!ret) {
+                CORE_WARN("recv http header from ip:{} failed", server_ip);
+                flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
+                co_return;
+            }
+
+            if (resp->get_status_code() == 302) {
+                http_client_->close();
+                http_client_.reset();
+                auto location = resp->get_header("Location");
+                CORE_DEBUG("HttpFlvClientSession:{} http response 302, redirect to:", get_session_name(),
+                           location.c_str());
+                if (!Utils::parse_url(location, protocol, domain, port, path, params)) {  // todo:add log
+                    CORE_ERROR("parse http url failed, url:%s", location.c_str());
+                    flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
+                    co_return;
+                }
+                // 获取域名ip
+                auto ip = DnsService::get_instance().get_ip(domain);
+                if (!ip) {
+                    CORE_ERROR("could not find ip for:%s", domain.c_str());
+                    flv_media_source_->set_status(E_SOURCE_STATUS_CONN_FAIL);
+                    co_return;
+                }
+
+                http_client_ = std::make_shared<HttpClient>(get_worker());
+                auto &server_ip = ip.value();
+
+                HttpRequest redirect_http_req;
+                redirect_http_req.set_method(GET);
+                redirect_http_req.set_path(path);
+                redirect_http_req.set_query_params(params);
+                redirect_http_req.set_version("1.1");
+                redirect_http_req.add_header("Content-Length", "0");
+                redirect_http_req.add_header("Accept", "*/*");
+                redirect_http_req.add_header("Connection",
+                                             "close");  // 表示发送完就结束，不是默认的keep-alive
+                redirect_http_req.add_header("Host", domain);
+                redirect_http_req.add_header("User-Agent", "mms-server");
+                http_client_->set_buffer_size(1024 * 1024);
+                resp = co_await http_client_->do_req(server_ip, port, redirect_http_req);
+            }
+
+            if (resp->get_status_code() != 200) {  // todo: notify media event
+                if (resp->get_status_code() == 403) {
+                    flv_media_source_->set_status(E_SOURCE_STATUS_FORBIDDEN);
+                } else if (resp->get_status_code() == 404) {
+                    flv_media_source_->set_status(E_SOURCE_STATUS_NOT_FOUND);
+                }
+                CORE_ERROR("http code error, code:{}", resp->get_status_code());
+                co_return;
+            }
+
+            co_await cycle_pull_flv_tag(resp);
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            ((void)exp);
+            wg_.done();
+            close();
+        });
     return;
 }
 
 boost::asio::awaitable<void> HttpFlvClientSession::cycle_pull_flv_tag(std::shared_ptr<HttpResponse> resp) {
     bool flv_header_received = false;
     // todo : 这里session已经在函数hold住了，lambda没必要传值，传值会导致内存异常
-    co_await resp->cycle_recv_body([this, &flv_header_received](const std::string_view & recv_data)->boost::asio::awaitable<int32_t> {
-        if (!flv_header_received) {
-            FlvHeader flv_header;
-            int32_t consumed = flv_header.decode((uint8_t*)recv_data.data(), recv_data.size());
-            if (consumed < 0) {
-                co_return -1;
-            } else if (consumed == 0) {
-                co_return 0;
-            }
-            flv_header_received = true;
-            co_return consumed;
-        } else {
-            if (recv_data.size() < 4) {
-                co_return 0;
-            }
-
-            prev_tag_size_ = ntohl(*(uint32_t*)recv_data.data());
-            if (!cache_tag_) {
-                cache_tag_ = std::make_shared<FlvTag>();
-            }
-
-            int32_t consumed = cache_tag_->decode_and_store((uint8_t *)recv_data.data() + 4, recv_data.size() - 4);
-            if (consumed < 0) {
-                co_return -1;
-            } else if (consumed == 0) {
-                co_return 0;
-            }
-
-            if (cache_tag_->get_tag_type() == FlvTagHeader::VideoTag) {
-                flv_media_source_->on_video_packet(cache_tag_);
-                cache_tag_ = nullptr;
-            } else if (cache_tag_->get_tag_type() == FlvTagHeader::AudioTag) {
-                flv_media_source_->on_audio_packet(cache_tag_);
-                cache_tag_ = nullptr;
+    co_await resp->cycle_recv_body(
+        [this, &flv_header_received](const std::string_view &recv_data) -> boost::asio::awaitable<int32_t> {
+            if (!flv_header_received) {
+                FlvHeader flv_header;
+                int32_t consumed = flv_header.decode((uint8_t *)recv_data.data(), recv_data.size());
+                if (consumed < 0) {
+                    co_return -1;
+                } else if (consumed == 0) {
+                    co_return 0;
+                }
+                flv_header_received = true;
+                co_return consumed;
             } else {
-                flv_media_source_->on_metadata(cache_tag_);
-                cache_tag_ = nullptr;
+                if (recv_data.size() < 4) {
+                    co_return 0;
+                }
+
+                prev_tag_size_ = ntohl(*(uint32_t *)recv_data.data());
+                if (!cache_tag_) {
+                    cache_tag_ = std::make_shared<FlvTag>();
+                }
+
+                int32_t consumed =
+                    cache_tag_->decode_and_store((uint8_t *)recv_data.data() + 4, recv_data.size() - 4);
+                if (consumed < 0) {
+                    co_return -1;
+                } else if (consumed == 0) {
+                    co_return 0;
+                }
+
+                if (cache_tag_->get_tag_type() == FlvTagHeader::VideoTag) {
+                    flv_media_source_->on_video_packet(cache_tag_);
+                    cache_tag_ = nullptr;
+                } else if (cache_tag_->get_tag_type() == FlvTagHeader::AudioTag) {
+                    flv_media_source_->on_audio_packet(cache_tag_);
+                    cache_tag_ = nullptr;
+                } else {
+                    flv_media_source_->on_metadata(cache_tag_);
+                    cache_tag_ = nullptr;
+                }
+                co_return consumed + 4;
             }
-            co_return consumed + 4;
-        }
-    });
+        });
     co_return;
 }
 
@@ -279,27 +286,32 @@ void HttpFlvClientSession::close() {
     }
 
     auto self(this->shared_from_this());
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        CORE_DEBUG("closing HttpFlvClientSession ...");
-        check_closable_timer_.cancel();
-        CORE_DEBUG("check_closable_timer cancel");
-        if (http_client_) {
-            http_client_->close();
-        }
-        CORE_DEBUG("close HttpFlvClientSession wait start");
-        co_await wg_.wait();
-        CORE_DEBUG("close HttpFlvClientSession wait start");
-        if (flv_media_source_) {
-            flv_media_source_->set_session(nullptr);
-            auto publish_app = flv_media_source_->get_app();
-            start_delayed_source_check_and_delete(publish_app->get_conf()->get_stream_resume_timeout(), flv_media_source_);
-            co_await publish_app->on_unpublish(std::static_pointer_cast<StreamSession>(shared_from_this()));
-        }
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            CORE_DEBUG("closing HttpFlvClientSession ...");
+            check_closable_timer_.cancel();
+            CORE_DEBUG("check_closable_timer cancel");
+            if (http_client_) {
+                http_client_->close();
+            }
+            CORE_DEBUG("close HttpFlvClientSession wait start");
+            co_await wg_.wait();
+            CORE_DEBUG("close HttpFlvClientSession wait start");
+            if (flv_media_source_) {
+                flv_media_source_->set_session(nullptr);
+                auto publish_app = flv_media_source_->get_app();
+                start_delayed_source_check_and_delete(publish_app->get_conf()->get_stream_resume_timeout(),
+                                                      flv_media_source_);
+                co_await publish_app->on_unpublish(
+                    std::static_pointer_cast<StreamSession>(shared_from_this()));
+            }
 
-        if (http_client_) {
-            http_client_.reset();
-        }
-        CORE_DEBUG("HttpFlvClientSession closed");
-        co_return;
-    }, boost::asio::detached);
+            if (http_client_) {
+                http_client_.reset();
+            }
+            CORE_DEBUG("HttpFlvClientSession closed");
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/client/rtmp/rtmp_play_client_session.cpp
+++ b/live-server/client/rtmp/rtmp_play_client_session.cpp
@@ -1,84 +1,74 @@
+#include "rtmp_play_client_session.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "rtmp_play_client_session.hpp"
 #include "app/publish_app.h"
+#include "base/network/tcp_socket.hpp"
+#include "base/network/tls_socket.hpp"
 #include "config/app_config.h"
 #include "config/cdn/origin_pull_config.h"
+#include "core/rtmp_media_sink.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "core/stream_session.hpp"
+#include "protocol/rtmp/amf0/amf0_inc.hpp"
+#include "protocol/rtmp/rtmp_define.hpp"
+#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_acknowledge_message.hpp"
+#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_set_chunk_size_message.hpp"
+#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_window_acknowledge_size_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_access_sample_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_command_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_onstatus_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_play_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_publish_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_set_peer_bandwidth_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_window_ack_size_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/user_ctrl_message/stream_begin_message.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
 #include "service/dns/dns_service.hpp"
 
 
-#include "core/rtmp_media_source.hpp"
-#include "core/rtmp_media_sink.hpp"
-#include "core/source_manager.hpp"
-#include "core/stream_session.hpp"
-
-#include "protocol/rtmp/rtmp_define.hpp"
-#include "protocol/rtmp/amf0/amf0_inc.hpp"
-
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_command_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_publish_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_play_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_window_ack_size_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_set_peer_bandwidth_message.hpp"
-#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_set_chunk_size_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_onstatus_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/user_ctrl_message/stream_begin_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_access_sample_message.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_window_acknowledge_size_message.hpp"
-#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_acknowledge_message.hpp"
-
-#include "base/network/tcp_socket.hpp"
-#include "base/network/tls_socket.hpp"
-
 using namespace mms;
-RtmpPlayClientSession::RtmpPlayClientSession(std::shared_ptr<PublishApp> app, ThreadWorker *worker, 
-                                             const std::string &domain_name, const std::string & app_name, const std::string & stream_name) : 
-                                             StreamSession(worker), 
-                                             rtmp_msgs_channel_(get_worker()->get_io_context(), 1024),
-                                             check_closable_timer_(worker->get_io_context()),
-                                             wg_(worker) {
+RtmpPlayClientSession::RtmpPlayClientSession(std::shared_ptr<PublishApp> app, ThreadWorker *worker,
+                                             const std::string &domain_name, const std::string &app_name,
+                                             const std::string &stream_name)
+    : StreamSession(worker),
+      rtmp_msgs_channel_(get_worker()->get_io_context(), 1024),
+      check_closable_timer_(worker->get_io_context()),
+      wg_(worker) {
     app_ = app;
     set_session_type("rtmp");
     set_session_info(domain_name, app_name, stream_name);
 }
 
-RtmpPlayClientSession::~RtmpPlayClientSession() {
-    CORE_DEBUG("destroy RtmpPlayClientSession");
-}
+RtmpPlayClientSession::~RtmpPlayClientSession() { CORE_DEBUG("destroy RtmpPlayClientSession"); }
 
-void RtmpPlayClientSession::on_socket_open(std::shared_ptr<SocketInterface> sock) {
-    (void)sock;
-}
+void RtmpPlayClientSession::on_socket_open(std::shared_ptr<SocketInterface> sock) { (void)sock; }
 
-void RtmpPlayClientSession::on_socket_close(std::shared_ptr<SocketInterface> sock) {
-    (void)sock;
-}
+void RtmpPlayClientSession::on_socket_close(std::shared_ptr<SocketInterface> sock) { (void)sock; }
 
 void RtmpPlayClientSession::service() {
     auto self(std::static_pointer_cast<RtmpPlayClientSession>(shared_from_this()));
-    auto media_source = SourceManager::get_instance().get_source(get_domain_name(),
-                                                                 get_app_name(),
-                                                                 get_stream_name());
+    auto media_source =
+        SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
     if (media_source) {
         return;
-    } 
+    }
 
     auto publish_app = std::static_pointer_cast<PublishApp>(app_);
-    rtmp_media_source_ = std::make_shared<RtmpMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
-    if (!SourceManager::get_instance().add_source(get_domain_name(), 
-                                                  get_app_name(),
-                                                  get_stream_name(),
+    rtmp_media_source_ =
+        std::make_shared<RtmpMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
+    if (!SourceManager::get_instance().add_source(get_domain_name(), get_app_name(), get_stream_name(),
                                                   rtmp_media_source_)) {
         return;
     }
@@ -89,7 +79,7 @@ void RtmpPlayClientSession::service() {
     uint16_t port;
     std::string path;
     std::unordered_map<std::string, std::string> params;
-    if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {//todo:add log
+    if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {  // todo:add log
         CORE_ERROR("parse url:{} failed", url_);
         return;
     }
@@ -107,129 +97,141 @@ void RtmpPlayClientSession::service() {
     chunk_protocol_ = std::make_unique<RtmpChunkProtocol>(conn_);
 
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto publish_app = std::static_pointer_cast<PublishApp>(app_);
-        while (1) {
-            check_closable_timer_.expires_from_now(std::chrono::milliseconds(pull_config_->no_players_timeout_ms()/2));//10s检查一次
-            co_await check_closable_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
-
-            if (!rtmp_media_source_) {
-                break;
-            }
-
-            if (rtmp_media_source_->has_no_sinks_for_time(pull_config_->no_players_timeout_ms())) {//已经30秒没人播放了
-                CORE_DEBUG("close RtmpPlayClientSession because no players for 10s");
-                break;
-            }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
-
-    wg_.add(1);
-    boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self, domain, path, port]()->boost::asio::awaitable<void> {
-        // 解析app名称
-        std::vector<std::string> vs;
-        boost::split(vs, path, boost::is_any_of("/"));
-        if (vs.size() <= 2) {
-            co_return;
-        }
-
-        //获取域名ip
-        auto ip = DnsService::get_instance().get_ip(domain);
-        if (!ip) {
-            CORE_ERROR("could not find ip for:%s", domain.c_str());
-            co_return;
-        }
-        auto & server_ip = ip.value();
-        // 连接
-        if (!co_await conn_->connect(server_ip, port)) {
-            CORE_ERROR("rtmp:connect to {}:{} failed", server_ip, port);
-            co_return;
-        }
-
-        // 启动握手
-        if (!co_await handshake_->do_client_handshake()) {
-            CORE_ERROR("rtmp:do_client_handshake failed");
-            co_return;
-        }
-
-        wg_.add(1);
-        // 启动发送协程
-        boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
             boost::system::error_code ec;
+            auto publish_app = std::static_pointer_cast<PublishApp>(app_);
             while (1) {
-                auto [rtmp_msgs, ch] = co_await rtmp_msgs_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
+                check_closable_timer_.expires_after(
+                    std::chrono::milliseconds(pull_config_->no_players_timeout_ms() / 2));  // 10s检查一次
+                co_await check_closable_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
                     break;
                 }
 
-                if (!(co_await chunk_protocol_->send_rtmp_messages(rtmp_msgs))) {
-                    if (ch) {
-                        ch->close();
-                    }
-                    CORE_ERROR("send rtmp message failed");
-                    co_return;
+                if (!rtmp_media_source_) {
+                    break;
                 }
 
-                if (ch) {
-                    ch->close();
+                if (rtmp_media_source_->has_no_sinks_for_time(
+                        pull_config_->no_players_timeout_ms())) {  // 已经30秒没人播放了
+                    CORE_DEBUG("close RtmpPlayClientSession because no players for 10s");
+                    break;
                 }
             }
             co_return;
-        }, [this](std::exception_ptr exp) {
+        },
+        [this, self](std::exception_ptr exp) {
             (void)exp;
             wg_.done();
             close();
-            CORE_DEBUG("RtmpPlayClientSession send coroutine exited");
         });
 
-        RtmpSetChunkSizeMessage set_chunk_size_msg(40960);
-        if (!co_await send_rtmp_message(set_chunk_size_msg)) {
-            co_return;
-        }
-        chunk_protocol_->set_out_chunk_size(40960);
+    wg_.add(1);
+    boost::asio::co_spawn(
+        conn_->get_worker()->get_io_context(),
+        [this, self, domain, path, port]() -> boost::asio::awaitable<void> {
+            // 解析app名称
+            std::vector<std::string> vs;
+            boost::split(vs, path, boost::is_any_of("/"));
+            if (vs.size() <= 2) {
+                co_return;
+            }
 
-        auto slash_pos = url_.find_last_of("/");
-        auto tc_url = url_.substr(0, slash_pos);
-        auto stream_and_params = url_.substr(slash_pos+1);
-        RtmpConnectCommandMessage connect_command_msg(transaction_id_++, tc_url, "", "", get_app_name());
-        if (!co_await send_rtmp_message(connect_command_msg)) {
-            co_return;
-        }
+            // 获取域名ip
+            auto ip = DnsService::get_instance().get_ip(domain);
+            if (!ip) {
+                CORE_ERROR("could not find ip for:%s", domain.c_str());
+                co_return;
+            }
+            auto &server_ip = ip.value();
+            // 连接
+            if (!co_await conn_->connect(server_ip, port)) {
+                CORE_ERROR("rtmp:connect to {}:{} failed", server_ip, port);
+                co_return;
+            }
 
-        RtmpCreateStreamMessage create_msg(transaction_id_++);
-        if (!co_await send_rtmp_message(create_msg)) {
-            CORE_ERROR("send create stream msg failed");
-            co_return;
-        }
+            // 启动握手
+            if (!co_await handshake_->do_client_handshake()) {
+                CORE_ERROR("rtmp:do_client_handshake failed");
+                co_return;
+            }
 
-        RtmpPlayMessage play_msg(transaction_id_++, stream_and_params);
-        if (!co_await send_rtmp_message(play_msg)) {
+            wg_.add(1);
+            // 启动发送协程
+            boost::asio::co_spawn(
+                conn_->get_worker()->get_io_context(),
+                [this, self]() -> boost::asio::awaitable<void> {
+                    boost::system::error_code ec;
+                    while (1) {
+                        auto [rtmp_msgs, ch] = co_await rtmp_msgs_channel_.async_receive(
+                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                        if (ec) {
+                            break;
+                        }
+
+                        if (!(co_await chunk_protocol_->send_rtmp_messages(rtmp_msgs))) {
+                            if (ch) {
+                                ch->close();
+                            }
+                            CORE_ERROR("send rtmp message failed");
+                            co_return;
+                        }
+
+                        if (ch) {
+                            ch->close();
+                        }
+                    }
+                    co_return;
+                },
+                [this](std::exception_ptr exp) {
+                    (void)exp;
+                    wg_.done();
+                    close();
+                    CORE_DEBUG("RtmpPlayClientSession send coroutine exited");
+                });
+
+            RtmpSetChunkSizeMessage set_chunk_size_msg(40960);
+            if (!co_await send_rtmp_message(set_chunk_size_msg)) {
+                co_return;
+            }
+            chunk_protocol_->set_out_chunk_size(40960);
+
+            auto slash_pos = url_.find_last_of("/");
+            auto tc_url = url_.substr(0, slash_pos);
+            auto stream_and_params = url_.substr(slash_pos + 1);
+            RtmpConnectCommandMessage connect_command_msg(transaction_id_++, tc_url, "", "", get_app_name());
+            if (!co_await send_rtmp_message(connect_command_msg)) {
+                co_return;
+            }
+
+            RtmpCreateStreamMessage create_msg(transaction_id_++);
+            if (!co_await send_rtmp_message(create_msg)) {
+                CORE_ERROR("send create stream msg failed");
+                co_return;
+            }
+
+            RtmpPlayMessage play_msg(transaction_id_++, stream_and_params);
+            if (!co_await send_rtmp_message(play_msg)) {
+                co_return;
+            }
+
+            // 循环接收chunk层收到的rtmp消息
+            co_await chunk_protocol_->cycle_recv_rtmp_message(
+                std::bind(&RtmpPlayClientSession::on_recv_rtmp_message, this, std::placeholders::_1));
             co_return;
-        }
-        
-        // 循环接收chunk层收到的rtmp消息
-        co_await chunk_protocol_->cycle_recv_rtmp_message(std::bind(&RtmpPlayClientSession::on_recv_rtmp_message, this, std::placeholders::_1));
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-        CORE_DEBUG("RtmpPlayClientSession recv coroutine exited");
-    });
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+            CORE_DEBUG("RtmpPlayClientSession recv coroutine exited");
+        });
 }
 
-void RtmpPlayClientSession::update_active_timestamp() {
-    last_active_time_ = Utils::get_current_ms();
-}
+void RtmpPlayClientSession::update_active_timestamp() { last_active_time_ = Utils::get_current_ms(); }
 
 void RtmpPlayClientSession::close() {
     // todo: how to record 404 error to log.
@@ -238,39 +240,37 @@ void RtmpPlayClientSession::close() {
     }
 
     auto self(this->shared_from_this());
-    boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        CORE_DEBUG("closing RtmpPlayClientSession...");
-        check_closable_timer_.cancel();
-        if (rtmp_msgs_channel_.is_open()) {//结束发送协程
-            rtmp_msgs_channel_.close();
-        }
+    boost::asio::co_spawn(
+        conn_->get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            CORE_DEBUG("closing RtmpPlayClientSession...");
+            check_closable_timer_.cancel();
+            if (rtmp_msgs_channel_.is_open()) {  // 结束发送协程
+                rtmp_msgs_channel_.close();
+            }
 
-        if (conn_) {
-            conn_->close();
-        }
+            if (conn_) {
+                conn_->close();
+            }
 
-        co_await wg_.wait();
+            co_await wg_.wait();
 
-    
-        if (conn_) {
-            conn_.reset();
-        }
-        CORE_DEBUG("RtmpPlayClientSession closed");
-        co_return;
-    }, boost::asio::detached);
+            if (conn_) {
+                conn_.reset();
+            }
+            CORE_DEBUG("RtmpPlayClientSession closed");
+            co_return;
+        },
+        boost::asio::detached);
 }
 
-void RtmpPlayClientSession::set_url(const std::string & url) {
-    url_ = url;
-}
+void RtmpPlayClientSession::set_url(const std::string &url) { url_ = url; }
 
-std::shared_ptr<RtmpMediaSource> RtmpPlayClientSession::get_rtmp_media_source() {
-    return rtmp_media_source_;
-}
+std::shared_ptr<RtmpMediaSource> RtmpPlayClientSession::get_rtmp_media_source() { return rtmp_media_source_; }
 
 boost::asio::awaitable<bool> RtmpPlayClientSession::send_acknowledge_msg_if_required() {
     int64_t delta = chunk_protocol_->get_last_ack_bytes() - conn_->get_in_bytes();
-    if (delta >= chunk_protocol_->get_in_window_acknowledge_size()/2) {//acknowledge
+    if (delta >= chunk_protocol_->get_in_window_acknowledge_size() / 2) {  // acknowledge
         RtmpAcknwledgeMessage ack_msg(conn_->get_in_bytes());
         if (!co_await send_rtmp_message(ack_msg)) {
             co_return false;
@@ -281,7 +281,8 @@ boost::asio::awaitable<bool> RtmpPlayClientSession::send_acknowledge_msg_if_requ
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPlayClientSession::on_recv_rtmp_message(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPlayClientSession::on_recv_rtmp_message(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     if (!co_await send_acknowledge_msg_if_required()) {
         co_return false;
     }
@@ -292,9 +293,9 @@ boost::asio::awaitable<bool> RtmpPlayClientSession::on_recv_rtmp_message(std::sh
         } else {
             co_return true;
         }
-    } 
+    }
 
-    switch(rtmp_msg->get_message_type()) {
+    switch (rtmp_msg->get_message_type()) {
         case RTMP_MESSAGE_TYPE_AUDIO: {
             co_return handle_audio_msg(rtmp_msg);
         }
@@ -317,25 +318,27 @@ boost::asio::awaitable<bool> RtmpPlayClientSession::on_recv_rtmp_message(std::sh
             co_return true;
         }
         default: {
-            
         }
     }
     co_return true;
 }
 // 异步方式发送rtmp消息
-boost::asio::awaitable<bool> RtmpPlayClientSession::send_rtmp_message(const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs) {
-    co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr, boost::asio::use_awaitable);
+boost::asio::awaitable<bool> RtmpPlayClientSession::send_rtmp_message(
+    const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs) {
+    co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr,
+                                           boost::asio::use_awaitable);
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     Amf0String command_name;
     auto payload = rtmp_msg->get_using_data();
-    int32_t consumed = command_name.decode((uint8_t*)payload.data(), payload.size());
+    int32_t consumed = command_name.decode((uint8_t *)payload.data(), payload.size());
     if (consumed < 0) {
         co_return false;
     }
-    
+
     auto name = command_name.get_value();
     if (name == "_result") {
         co_return co_await handle_amf0_result_command(rtmp_msg);
@@ -346,14 +349,15 @@ boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_command(std::sha
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_status_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_status_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     RtmpOnStatusMessage status_command;
     auto consumed = status_command.decode(rtmp_msg);
     if (consumed < 0) {
         co_return false;
     }
-    
-    auto & info = status_command.info();
+
+    auto &info = status_command.info();
     auto code = info.get_property<Amf0String>("code");
     if (!code) {
         co_return false;
@@ -365,11 +369,12 @@ boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_status_command(s
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_result_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPlayClientSession::handle_amf0_result_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     (void)rtmp_msg;
     co_return true;
 }
-    
+
 bool RtmpPlayClientSession::handle_video_msg(std::shared_ptr<RtmpMessage> msg) {
     return rtmp_media_source_->on_video_packet(msg);
 }
@@ -378,24 +383,23 @@ bool RtmpPlayClientSession::handle_audio_msg(std::shared_ptr<RtmpMessage> msg) {
     return rtmp_media_source_->on_audio_packet(msg);
 }
 
-
-bool RtmpPlayClientSession::handle_amf0_data(std::shared_ptr<RtmpMessage> rtmp_msg) {//usually is metadata
+bool RtmpPlayClientSession::handle_amf0_data(std::shared_ptr<RtmpMessage> rtmp_msg) {  // usually is metadata
     Amf0String command_name;
     auto payload = rtmp_msg->get_using_data();
-    int32_t consumed = command_name.decode((uint8_t*)payload.data(), payload.size());
+    int32_t consumed = command_name.decode((uint8_t *)payload.data(), payload.size());
     if (consumed < 0) {
         return false;
     }
-    
+
     auto name = command_name.get_value();
-    if (name == "onMetaData"  || name == "@setDataFrame") {
+    if (name == "onMetaData" || name == "@setDataFrame") {
         return rtmp_media_source_->on_metadata(rtmp_msg);
     }
     return true;
 }
 
 bool RtmpPlayClientSession::handle_acknowledgement(std::shared_ptr<RtmpMessage> rtmp_msg) {
-    // todo 
+    // todo
     // nothing to do
     (void)rtmp_msg;
     return true;

--- a/live-server/client/rtmp/rtmp_publish_client_session.cpp
+++ b/live-server/client/rtmp/rtmp_publish_client_session.cpp
@@ -1,72 +1,64 @@
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
-#include <boost/asio/redirect_error.hpp>
-
-#include "app/publish_app.h"
-#include "base/utils/utils.h"
-#include "service/dns/dns_service.hpp"
-
-#include "protocol/rtmp/amf0/amf0_inc.hpp"
-#include "protocol/rtmp/rtmp_define.hpp"
-#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_window_ack_size_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_set_peer_bandwidth_message.hpp"
-#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_set_chunk_size_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_resp_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_onstatus_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/user_ctrl_message/stream_begin_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_access_sample_message.hpp"
-#include "protocol/rtmp/rtmp_handshake.hpp"
-#include "protocol/rtmp/rtmp_chunk_protocol.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_command_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_publish_message.hpp"
-#include "protocol/rtmp/rtmp_message/command_message/rtmp_play_message.hpp"
-#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_acknowledge_message.hpp"
-
-#include "core/rtmp_media_source.hpp"
-#include "core/rtmp_media_sink.hpp"
-#include "core/source_manager.hpp"
-#include "core/stream_session.hpp"
-
 #include "rtmp_publish_client_session.hpp"
 
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include "app/publish_app.h"
 #include "base/network/tcp_socket.hpp"
 #include "base/network/tls_socket.hpp"
+#include "base/utils/utils.h"
+#include "core/rtmp_media_sink.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "core/stream_session.hpp"
+#include "protocol/rtmp/amf0/amf0_inc.hpp"
+#include "protocol/rtmp/rtmp_chunk_protocol.hpp"
+#include "protocol/rtmp/rtmp_define.hpp"
+#include "protocol/rtmp/rtmp_handshake.hpp"
+#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_acknowledge_message.hpp"
+#include "protocol/rtmp/rtmp_message/chunk_message/rtmp_set_chunk_size_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_access_sample_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_command_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_connect_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_create_stream_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_fcpublish_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_onstatus_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_play_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_publish_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_release_stream_resp_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_set_peer_bandwidth_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/rtmp_window_ack_size_message.hpp"
+#include "protocol/rtmp/rtmp_message/command_message/user_ctrl_message/stream_begin_message.hpp"
+#include "protocol/rtmp/rtmp_message/data_message/rtmp_metadata_message.hpp"
+#include "service/dns/dns_service.hpp"
+
 
 using namespace mms;
-RtmpPublishClientSession::RtmpPublishClientSession(std::weak_ptr<RtmpMediaSource> source, std::shared_ptr<PublishApp> app, ThreadWorker *worker) : StreamSession(worker),
-                                                    rtmp_msgs_channel_(get_worker()->get_io_context(), 1024),
-                                                    check_closable_timer_(worker->get_io_context()),
-                                                    alive_timeout_timer_(worker->get_io_context()),
-                                                    wg_(worker) {
+RtmpPublishClientSession::RtmpPublishClientSession(std::weak_ptr<RtmpMediaSource> source,
+                                                   std::shared_ptr<PublishApp> app, ThreadWorker *worker)
+    : StreamSession(worker),
+      rtmp_msgs_channel_(get_worker()->get_io_context(), 1024),
+      check_closable_timer_(worker->get_io_context()),
+      alive_timeout_timer_(worker->get_io_context()),
+      wg_(worker) {
     rtmp_source_ = source;
     app_ = app;
     rtmp_media_sink_ = std::make_shared<RtmpMediaSink>(worker_);
     set_session_type("rtmp");
 }
 
-RtmpPublishClientSession::~RtmpPublishClientSession() {
-    spdlog::debug("destroy RtmpPublishClientSession");
-}
+RtmpPublishClientSession::~RtmpPublishClientSession() { spdlog::debug("destroy RtmpPublishClientSession"); }
 
-void RtmpPublishClientSession::on_socket_open(std::shared_ptr<SocketInterface> sock) {
-    (void)sock;
-}
+void RtmpPublishClientSession::on_socket_open(std::shared_ptr<SocketInterface> sock) { (void)sock; }
 
-void RtmpPublishClientSession::on_socket_close(std::shared_ptr<SocketInterface> sock) {
-    (void)sock;
-}
+void RtmpPublishClientSession::on_socket_close(std::shared_ptr<SocketInterface> sock) { (void)sock; }
 
-std::shared_ptr<RtmpMediaSink> RtmpPublishClientSession::get_rtmp_media_sink() {
-    return rtmp_media_sink_;
-}
+std::shared_ptr<RtmpMediaSink> RtmpPublishClientSession::get_rtmp_media_sink() { return rtmp_media_sink_; }
 
 void RtmpPublishClientSession::service() {
     auto self(this->shared_from_this());
@@ -76,7 +68,7 @@ void RtmpPublishClientSession::service() {
     uint16_t port;
     std::string path;
     std::unordered_map<std::string, std::string> params;
-    if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {//todo:add log
+    if (!Utils::parse_url(url_, protocol, domain, port, path, params)) {  // todo:add log
         spdlog::error("parse url:{} failed", url_);
         return;
     }
@@ -92,118 +84,132 @@ void RtmpPublishClientSession::service() {
     handshake_ = std::make_unique<RtmpHandshake>(conn_);
     chunk_protocol_ = std::make_unique<RtmpChunkProtocol>(conn_);
 
-    boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self, domain, path, port]()->boost::asio::awaitable<void> {
-        spdlog::debug("start push rtmp, url:{}", url_);
-        // 解析app名称
-        std::vector<std::string> vs;
-        boost::split(vs, path, boost::is_any_of("/"));
-        if (vs.size() <= 2) {
-            co_return;
-        }
-        set_session_info(domain, vs[1], vs[2]);
-        //获取域名ip
-        auto ip = DnsService::get_instance().get_ip(domain);
-        if (!ip) {
-            spdlog::debug("could not find ip for:%s", domain.c_str());
-            co_return;
-        }
-        auto & server_ip = ip.value();
-        // 连接
-        if (!co_await conn_->connect(server_ip, port)) {
-            spdlog::debug("RtmpPublishClientSession connect to {}:{} failed", server_ip, port);
-            co_return;
-        }
+    boost::asio::co_spawn(
+        conn_->get_worker()->get_io_context(),
+        [this, self, domain, path, port]() -> boost::asio::awaitable<void> {
+            spdlog::debug("start push rtmp, url:{}", url_);
+            // 解析app名称
+            std::vector<std::string> vs;
+            boost::split(vs, path, boost::is_any_of("/"));
+            if (vs.size() <= 2) {
+                co_return;
+            }
+            set_session_info(domain, vs[1], vs[2]);
+            // 获取域名ip
+            auto ip = DnsService::get_instance().get_ip(domain);
+            if (!ip) {
+                spdlog::debug("could not find ip for:%s", domain.c_str());
+                co_return;
+            }
+            auto &server_ip = ip.value();
+            // 连接
+            if (!co_await conn_->connect(server_ip, port)) {
+                spdlog::debug("RtmpPublishClientSession connect to {}:{} failed", server_ip, port);
+                co_return;
+            }
 
-        // 启动握手
-        if (!co_await handshake_->do_client_handshake()) {
-            spdlog::debug("RtmpPublishClientSession do_client_handshake failed");
-            co_return;
-        }
-        spdlog::debug("RtmpPublishClientSession do_client_handshake done");
-        // 启动发送协程
-        wg_.add(1);
-        boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-            boost::system::error_code ec;
-            while (1) {
-                auto [rtmp_msgs, ch] = co_await rtmp_msgs_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
-                    break;
-                }
+            // 启动握手
+            if (!co_await handshake_->do_client_handshake()) {
+                spdlog::debug("RtmpPublishClientSession do_client_handshake failed");
+                co_return;
+            }
+            spdlog::debug("RtmpPublishClientSession do_client_handshake done");
+            // 启动发送协程
+            wg_.add(1);
+            boost::asio::co_spawn(
+                conn_->get_worker()->get_io_context(),
+                [this, self]() -> boost::asio::awaitable<void> {
+                    boost::system::error_code ec;
+                    while (1) {
+                        auto [rtmp_msgs, ch] = co_await rtmp_msgs_channel_.async_receive(
+                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                        if (ec) {
+                            break;
+                        }
 
-                update_active_timestamp();
-                if (!(co_await chunk_protocol_->send_rtmp_messages(rtmp_msgs))) {
-                    if (ch) {
-                        ch->close();
+                        update_active_timestamp();
+                        if (!(co_await chunk_protocol_->send_rtmp_messages(rtmp_msgs))) {
+                            if (ch) {
+                                ch->close();
+                            }
+                            co_return;
+                        }
+
+                        if (ch) {
+                            ch->close();
+                        }
                     }
                     co_return;
-                }
+                },
+                [this, self](std::exception_ptr exp) {
+                    (void)exp;
+                    wg_.done();
+                    close();
+                    spdlog::debug("RtmpPublishClientSession send coroutine exited");
+                });
 
-                if (ch) {
-                    ch->close();
-                }
+            // 循环接收chunk层收到的rtmp消息
+            wg_.add(1);
+            boost::asio::co_spawn(
+                conn_->get_worker()->get_io_context(),
+                [this, self]() -> boost::asio::awaitable<void> {
+                    int32_t ret = co_await chunk_protocol_->cycle_recv_rtmp_message(std::bind(
+                        &RtmpPublishClientSession::on_recv_rtmp_message, this, std::placeholders::_1));
+                    spdlog::debug("RtmpPublishClientSession cycle_recv_rtmp_message return, ret:{}", ret);
+                },
+                [this, self](std::exception_ptr exp) {
+                    (void)exp;
+                    wg_.done();
+                    close();
+                });
+            start_alive_checker();
+
+            RtmpSetChunkSizeMessage set_chunk_size_msg(40960);
+            if (!co_await send_rtmp_message(set_chunk_size_msg)) {
+                co_return;
             }
-            co_return;
-        }, [this, self](std::exception_ptr exp) {
-            (void)exp;
-            wg_.done();
-            close();
-            spdlog::debug("RtmpPublishClientSession send coroutine exited");
-        });
+            chunk_protocol_->set_out_chunk_size(40960);
 
-        // 循环接收chunk层收到的rtmp消息
-        wg_.add(1);
-        boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-            int32_t ret = co_await chunk_protocol_->cycle_recv_rtmp_message(std::bind(&RtmpPublishClientSession::on_recv_rtmp_message, this, std::placeholders::_1));
-            spdlog::debug("RtmpPublishClientSession cycle_recv_rtmp_message return, ret:{}", ret);
-        }, [this, self](std::exception_ptr exp) {
-            (void)exp;
-            wg_.done();
-            close();
-        });
-        start_alive_checker();
+            auto slash_pos = url_.find_last_of("/");
+            auto tc_url = url_.substr(0, slash_pos);
+            auto stream_and_params = url_.substr(slash_pos + 1);
+            RtmpConnectCommandMessage connect_command_msg(transaction_id_++, tc_url, "", "", get_app_name());
+            if (!co_await send_rtmp_message(connect_command_msg)) {
+                co_return;
+            }
 
-        RtmpSetChunkSizeMessage set_chunk_size_msg(40960);
-        if (!co_await send_rtmp_message(set_chunk_size_msg)) {
-            co_return;
-        }
-        chunk_protocol_->set_out_chunk_size(40960);
+            RtmpReleaseStreamMessage release_stream_msg(transaction_id_++, stream_and_params);
+            if (!co_await send_rtmp_message(release_stream_msg)) {
+                spdlog::error("send create stream msg failed");
+                co_return;
+            }
 
-        auto slash_pos = url_.find_last_of("/");
-        auto tc_url = url_.substr(0, slash_pos);
-        auto stream_and_params = url_.substr(slash_pos+1);
-        RtmpConnectCommandMessage connect_command_msg(transaction_id_++, tc_url, "", "", get_app_name());
-        if (!co_await send_rtmp_message(connect_command_msg)) {
-            co_return;
-        }
-        
-        RtmpReleaseStreamMessage release_stream_msg(transaction_id_++, stream_and_params);
-        if (!co_await send_rtmp_message(release_stream_msg)) {
-            spdlog::error("send create stream msg failed");
-            co_return;
-        }
+            RtmpFCPublishMessage publish_msg(transaction_id_++, stream_and_params);
+            if (!co_await send_rtmp_message(publish_msg)) {
+                co_return;
+            }
 
-        RtmpFCPublishMessage publish_msg(transaction_id_++, stream_and_params);
-        if (!co_await send_rtmp_message(publish_msg)) {
-            co_return;
-        }
+            RtmpCreateStreamMessage create_msg(transaction_id_++);
+            if (!co_await send_rtmp_message(create_msg)) {
+                co_return;
+            }
 
-        RtmpCreateStreamMessage create_msg(transaction_id_++);
-        if (!co_await send_rtmp_message(create_msg)) {
-            co_return;
-        }
+            RtmpPublishMessage pub_msg(transaction_id_++, stream_and_params, "live");
+            if (!co_await send_rtmp_message(pub_msg)) {
+                co_return;
+            }
 
-        RtmpPublishMessage pub_msg(transaction_id_++, stream_and_params, "live");
-        if (!co_await send_rtmp_message(pub_msg)) {
-            co_return;
-        }
+            rtmp_media_sink_->on_rtmp_message(
+                [this](const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs)
+                    -> boost::asio::awaitable<bool> {
+                    co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr,
+                                                           boost::asio::use_awaitable);
+                    co_return true;
+                });
 
-        rtmp_media_sink_->on_rtmp_message([this](const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs)->boost::asio::awaitable<bool> {
-            co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr, boost::asio::use_awaitable);
-            co_return true;
-        });
-        
-        co_return;
-    }, boost::asio::detached);
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 void RtmpPublishClientSession::close() {
@@ -213,50 +219,50 @@ void RtmpPublishClientSession::close() {
     }
 
     auto self(this->shared_from_this());
-    boost::asio::co_spawn(conn_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        spdlog::debug("closing RtmpPublishClientSession...");
-        check_closable_timer_.cancel();
-        alive_timeout_timer_.cancel();
-        if (conn_) {
-            conn_->close();
-        }
-
-        if (rtmp_msgs_channel_.is_open()) {//结束发送协程
-            rtmp_msgs_channel_.close();
-        }
-
-        co_await wg_.wait();
-
-        if (rtmp_media_sink_) {
-            auto s = SourceManager::get_instance().get_source(get_domain_name(),
-                                                              get_app_name(),
-                                                              get_stream_name());
-            if (s) {
-                s->remove_media_sink(rtmp_media_sink_);
+    boost::asio::co_spawn(
+        conn_->get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            spdlog::debug("closing RtmpPublishClientSession...");
+            check_closable_timer_.cancel();
+            alive_timeout_timer_.cancel();
+            if (conn_) {
+                conn_->close();
             }
+
+            if (rtmp_msgs_channel_.is_open()) {  // 结束发送协程
+                rtmp_msgs_channel_.close();
+            }
+
+            co_await wg_.wait();
 
             if (rtmp_media_sink_) {
-                rtmp_media_sink_->on_rtmp_message({});
-                rtmp_media_sink_->close();
-                rtmp_media_sink_ = nullptr;
+                auto s = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(),
+                                                                  get_stream_name());
+                if (s) {
+                    s->remove_media_sink(rtmp_media_sink_);
+                }
+
+                if (rtmp_media_sink_) {
+                    rtmp_media_sink_->on_rtmp_message({});
+                    rtmp_media_sink_->close();
+                    rtmp_media_sink_ = nullptr;
+                }
             }
-        } 
 
-        if (conn_) {
-            conn_.reset();
-        }
-        spdlog::debug("close RtmpPublishClientSession done");
-        co_return;
-    }, boost::asio::detached);
+            if (conn_) {
+                conn_.reset();
+            }
+            spdlog::debug("close RtmpPublishClientSession done");
+            co_return;
+        },
+        boost::asio::detached);
 }
 
-void RtmpPublishClientSession::set_url(const std::string & url) {
-    url_ = url;
-}
+void RtmpPublishClientSession::set_url(const std::string &url) { url_ = url; }
 
 boost::asio::awaitable<bool> RtmpPublishClientSession::send_acknowledge_msg_if_required() {
     int64_t delta = chunk_protocol_->get_last_ack_bytes() - conn_->get_in_bytes();
-    if (delta >= chunk_protocol_->get_in_window_acknowledge_size()/2) {//acknowledge
+    if (delta >= chunk_protocol_->get_in_window_acknowledge_size() / 2) {  // acknowledge
         RtmpAcknwledgeMessage ack_msg(conn_->get_in_bytes());
         if (!co_await send_rtmp_message(ack_msg)) {
             co_return false;
@@ -270,35 +276,38 @@ boost::asio::awaitable<bool> RtmpPublishClientSession::send_acknowledge_msg_if_r
 void RtmpPublishClientSession::start_alive_checker() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
             boost::system::error_code ec;
             while (1) {
-                alive_timeout_timer_.expires_from_now(std::chrono::seconds(10));
-                co_await alive_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                alive_timeout_timer_.expires_after(std::chrono::seconds(10));
+                co_await alive_timeout_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
                 if (ec) {
                     co_return;
                 }
 
                 int64_t now_ms = Utils::get_current_ms();
-                if (now_ms - last_active_time_ >= 5000) {//5秒没数据，超时
-                    spdlog::warn("rtmp session:{} is not alive, last_active_time:{}", get_session_name(), last_active_time_);
+                if (now_ms - last_active_time_ >= 5000) {  // 5秒没数据，超时
+                    spdlog::warn("rtmp session:{} is not alive, last_active_time:{}", get_session_name(),
+                                 last_active_time_);
                     co_return;
                 }
             }
             co_return;
-        }, [this, self](std::exception_ptr exp) {
+        },
+        [this, self](std::exception_ptr exp) {
             (void)exp;
             close();
             wg_.done();
-        }
-    );
+        });
 }
 
-void RtmpPublishClientSession::update_active_timestamp() {
-    last_active_time_ = Utils::get_current_ms();
-}
+void RtmpPublishClientSession::update_active_timestamp() { last_active_time_ = Utils::get_current_ms(); }
 
-boost::asio::awaitable<bool> RtmpPublishClientSession::on_recv_rtmp_message(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPublishClientSession::on_recv_rtmp_message(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     update_active_timestamp();
     if (!co_await send_acknowledge_msg_if_required()) {
         co_return false;
@@ -310,9 +319,9 @@ boost::asio::awaitable<bool> RtmpPublishClientSession::on_recv_rtmp_message(std:
         } else {
             co_return true;
         }
-    } 
+    }
 
-    switch(rtmp_msg->get_message_type()) {
+    switch (rtmp_msg->get_message_type()) {
         case RTMP_MESSAGE_TYPE_AMF0_COMMAND: {
             co_return co_await handle_amf0_command(rtmp_msg);
         }
@@ -326,22 +335,24 @@ boost::asio::awaitable<bool> RtmpPublishClientSession::on_recv_rtmp_message(std:
             co_return true;
         }
         default: {
-            
         }
     }
     co_return true;
 }
 
 // 异步方式发送rtmp消息
-boost::asio::awaitable<bool> RtmpPublishClientSession::send_rtmp_message(const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs) {
-    co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr, boost::asio::use_awaitable);
+boost::asio::awaitable<bool> RtmpPublishClientSession::send_rtmp_message(
+    const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs) {
+    co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, rtmp_msgs, nullptr,
+                                           boost::asio::use_awaitable);
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     Amf0String command_name;
     auto payload = rtmp_msg->get_using_data();
-    int32_t consumed = command_name.decode((uint8_t*)payload.data(), payload.size());
+    int32_t consumed = command_name.decode((uint8_t *)payload.data(), payload.size());
     if (consumed < 0) {
         co_return false;
     }
@@ -357,14 +368,15 @@ boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_command(std::
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_status_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_status_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     RtmpOnStatusMessage status_command;
     auto consumed = status_command.decode(rtmp_msg);
     if (consumed < 0) {
         co_return false;
     }
-    
-    auto & info = status_command.info();
+
+    auto &info = status_command.info();
     auto code = info.get_property<Amf0String>("code");
     if (!code) {
         co_return false;
@@ -384,13 +396,14 @@ boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_status_comman
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_result_command(std::shared_ptr<RtmpMessage> rtmp_msg) {
+boost::asio::awaitable<bool> RtmpPublishClientSession::handle_amf0_result_command(
+    std::shared_ptr<RtmpMessage> rtmp_msg) {
     (void)rtmp_msg;
     co_return true;
 }
 
 bool RtmpPublishClientSession::handle_acknowledgement(std::shared_ptr<RtmpMessage> rtmp_msg) {
-    // todo 
+    // todo
     // nothing to do
     (void)rtmp_msg;
     return true;

--- a/live-server/client/rtmp/rtmp_publish_client_session.hpp
+++ b/live-server/client/rtmp/rtmp_publish_client_session.hpp
@@ -1,10 +1,18 @@
 #pragma once
 
-#include <memory>
-#include <boost/asio/experimental/channel.hpp>
+#include <base/network/socket_interface.hpp>
+#include <base/thread/thread_worker.hpp>
 #include <boost/algorithm/string.hpp>
-#include "base/wait_group.h"
+#include <boost/asio/experimental/channel.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <core/stream_session.hpp>
+#include <memory>
+#include <rtmp_chunk_protocol.hpp>
+#include <rtmp_define.hpp>
+#include <rtmp_handshake.hpp>
+
 #include "base/utils/utils.h"
+#include "base/wait_group.h"
 
 namespace mms {
 class EdgePushConfig;
@@ -14,41 +22,45 @@ class PublishApp;
 
 class RtmpPublishClientSession : public StreamSession, public SocketInterfaceHandler {
 public:
-    RtmpPublishClientSession(std::weak_ptr<RtmpMediaSource> source, std::shared_ptr<PublishApp> app, ThreadWorker *worker);
+    RtmpPublishClientSession(std::weak_ptr<RtmpMediaSource> source, std::shared_ptr<PublishApp> app,
+                             ThreadWorker *worker);
     virtual ~RtmpPublishClientSession();
     void on_socket_open(std::shared_ptr<SocketInterface> sock) override;
     void on_socket_close(std::shared_ptr<SocketInterface> sock) override;
     void service() override;
     void close() override;
-    void set_url(const std::string & url);
-    void set_push_config(std::shared_ptr<EdgePushConfig> push_config) {
-        push_config_ = push_config;
-    }
+    void set_url(const std::string &url);
+    void set_push_config(std::shared_ptr<EdgePushConfig> push_config) { push_config_ = push_config; }
     std::shared_ptr<RtmpMediaSink> get_rtmp_media_sink();
+
 protected:
     // 同步方式发送rtmp消息，发送完成后会等待
-    template<typename T>
-    boost::asio::awaitable<bool> send_rtmp_message(const T & msg) {
+    template <typename T>
+    boost::asio::awaitable<bool> send_rtmp_message(const T &msg) {
         boost::system::error_code ec;
         std::shared_ptr<RtmpMessage> rtmp_msg = msg.encode();
         if (!rtmp_msg) {
             co_return false;
         }
 
-        boost::asio::experimental::channel<void(boost::system::error_code, bool)> wait_channel(conn_->get_worker()->get_io_context());
+        boost::asio::experimental::channel<void(boost::system::error_code, bool)> wait_channel(
+            conn_->get_worker()->get_io_context());
         std::vector<std::shared_ptr<RtmpMessage>> v = {rtmp_msg};
-        co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, v, &wait_channel, boost::asio::use_awaitable);
+        co_await rtmp_msgs_channel_.async_send(boost::system::error_code{}, v, &wait_channel,
+                                               boost::asio::use_awaitable);
         co_await wait_channel.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
+
 private:
     void update_active_timestamp();
     void start_alive_checker();
-    
+
     boost::asio::awaitable<bool> send_acknowledge_msg_if_required();
     boost::asio::awaitable<bool> on_recv_rtmp_message(std::shared_ptr<RtmpMessage> rtmp_msg);
     // 异步方式发送rtmp消息
-    boost::asio::awaitable<bool> send_rtmp_message(const std::vector<std::shared_ptr<RtmpMessage>> & rtmp_msgs);
+    boost::asio::awaitable<bool> send_rtmp_message(
+        const std::vector<std::shared_ptr<RtmpMessage>> &rtmp_msgs);
     boost::asio::awaitable<bool> handle_amf0_command(std::shared_ptr<RtmpMessage> rtmp_msg);
     boost::asio::awaitable<bool> handle_amf0_status_command(std::shared_ptr<RtmpMessage> rtmp_msg);
     boost::asio::awaitable<bool> handle_amf0_result_command(std::shared_ptr<RtmpMessage> rtmp_msg);
@@ -59,6 +71,7 @@ private:
     std::unique_ptr<RtmpHandshake> handshake_;
     std::unique_ptr<RtmpChunkProtocol> chunk_protocol_;
     uint32_t window_ack_size_ = 80000000;
+
 private:
     std::shared_ptr<EdgePushConfig> push_config_;
     std::string url_;
@@ -67,7 +80,9 @@ private:
     std::shared_ptr<RtmpMediaSink> rtmp_media_sink_;
 
     using SYNC_CHANNEL = boost::asio::experimental::channel<void(boost::system::error_code, bool)>;
-    boost::asio::experimental::channel<void(boost::system::error_code, std::vector<std::shared_ptr<RtmpMessage>>, SYNC_CHANNEL*)> rtmp_msgs_channel_;
+    boost::asio::experimental::channel<void(boost::system::error_code,
+                                            std::vector<std::shared_ptr<RtmpMessage>>, SYNC_CHANNEL *)>
+        rtmp_msgs_channel_;
 
     int64_t last_active_time_ = Utils::get_current_ms();
     boost::asio::steady_timer check_closable_timer_;
@@ -76,4 +91,4 @@ private:
     WaitGroup wg_;
 };
 
-};
+};  // namespace mms

--- a/live-server/core/stream_session.cpp
+++ b/live-server/core/stream_session.cpp
@@ -1,48 +1,49 @@
+#include "stream_session.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "base/thread/thread_worker.hpp"
-
-#include "stream_session.hpp"
+#include "app/app.h"
+#include "app/app_manager.h"
 #include "base/thread/thread_worker.hpp"
 #include "config/config.h"
-#include "app/app_manager.h"
-#include "app/app.h"
 #include "core/media_source.hpp"
 #include "core/source_manager.hpp"
 #include "log/log.h"
 
+
 using namespace mms;
 
-StreamSession::StreamSession(ThreadWorker *worker) : Session(worker), wg_(worker), cleanup_timer_(worker->get_io_context()) {
-}
+StreamSession::StreamSession(ThreadWorker *worker)
+    : Session(worker), wg_(worker), cleanup_timer_(worker->get_io_context()) {}
 
-StreamSession::~StreamSession() {
+StreamSession::~StreamSession() {}
 
-}
-
-void StreamSession::set_session_info(const std::string & domain, const std::string & app_name, const std::string & stream_name) {
+void StreamSession::set_session_info(const std::string &domain, const std::string &app_name,
+                                     const std::string &stream_name) {
     domain_name_ = domain;
     app_name_ = app_name;
     stream_name_ = stream_name;
     session_name_ = domain_name_ + "/" + app_name_ + "/" + stream_name_;
 }
 
-void StreamSession::set_session_info(const std::string_view & domain, const std::string_view & app_name, const std::string_view & stream_name) {
+void StreamSession::set_session_info(const std::string_view &domain, const std::string_view &app_name,
+                                     const std::string_view &stream_name) {
     domain_name_ = domain;
     app_name_ = app_name;
     stream_name_ = stream_name;
     session_name_ = domain_name_ + "/" + app_name_ + "/" + stream_name_;
 }
 
-bool StreamSession::find_and_set_app(const std::string & domain, const std::string & app_name, bool is_publish) {
+bool StreamSession::find_and_set_app(const std::string &domain, const std::string &app_name,
+                                     bool is_publish) {
     auto app = AppManager::get_instance().get_app(domain, app_name);
     if (!app) {
         return false;
     }
-    
+
     if (app->is_publish_app() != is_publish) {
         CORE_WARN("app: {} is not publish app", app_name);
         return false;
@@ -53,7 +54,8 @@ bool StreamSession::find_and_set_app(const std::string & domain, const std::stri
     return true;
 }
 
-void StreamSession::start_delayed_source_check_and_delete(uint32_t delay_sec, std::shared_ptr<MediaSource> media_source) {
+void StreamSession::start_delayed_source_check_and_delete(uint32_t delay_sec,
+                                                          std::shared_ptr<MediaSource> media_source) {
     auto self(shared_from_this());
     if (waiting_cleanup_) {
         return;
@@ -61,28 +63,31 @@ void StreamSession::start_delayed_source_check_and_delete(uint32_t delay_sec, st
 
     waiting_cleanup_ = true;
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self, delay_sec, media_source]()->boost::asio::awaitable<void> {
-        cleanup_timer_.expires_from_now(std::chrono::milliseconds(delay_sec*1000));
-        boost::system::error_code ec;
-        co_await cleanup_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-        if (ec) {
-            co_return;//被cancel了，可能是重新绑定了，不需要检查le
-        }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self, delay_sec, media_source]() -> boost::asio::awaitable<void> {
+            cleanup_timer_.expires_after(std::chrono::seconds(delay_sec));
+            boost::system::error_code ec;
+            co_await cleanup_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return;  // 被cancel了，可能是重新绑定了，不需要检查le
+            }
 
-        auto session = media_source->get_session();
-        if (!session) {// session已经解除绑定，那么可以删除
-            // source是由session创建的，也应该在session中进行移除
-            SourceManager::get_instance().remove_source(domain_name_, app_name_, stream_name_);
-            media_source->close();
-        } else if (session != self) {
-            CORE_DEBUG("source:{} is changed session", get_session_name());
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        waiting_cleanup_ = false;
-        wg_.done();
-    });
+            auto session = media_source->get_session();
+            if (!session) {  // session已经解除绑定，那么可以删除
+                // source是由session创建的，也应该在session中进行移除
+                SourceManager::get_instance().remove_source(domain_name_, app_name_, stream_name_);
+                media_source->close();
+            } else if (session != self) {
+                CORE_DEBUG("source:{} is changed session", get_session_name());
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            waiting_cleanup_ = false;
+            wg_.done();
+        });
 }
 
 // void StreamSession::stop_source_delay_check_and_delete() {
@@ -91,7 +96,8 @@ void StreamSession::start_delayed_source_check_and_delete(uint32_t delay_sec, st
 //         co_return;
 //     }
 
-//     boost::asio::co_spawn(worker_->get_io_context(), [this, self, media_source]()->boost::asio::awaitable<void> {
+//     boost::asio::co_spawn(worker_->get_io_context(), [this, self,
+//     media_source]()->boost::asio::awaitable<void> {
 //         cleanup_timer_.cancel();
 //         co_await wg_.wait();
 //     }, boost::asio::detached);

--- a/live-server/main.cpp
+++ b/live-server/main.cpp
@@ -1,49 +1,45 @@
 #include <limits.h>
 #include <sys/resource.h>
 
-#include <iostream>
 #include <atomic>
-
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/program_options.hpp>
+#include <iostream>
 
-#include "version.h"
-#include "log/log.h"
-
-#include "config/config.h"
 #include "base/thread/thread_pool.hpp"
 #include "base/utils/utils.h"
-
-#include "server/rtmp/rtmp_server.hpp"
-#include "server/rtmp/rtmps_server.hpp"
+#include "config/config.h"
+#include "log/log.h"
+#include "server/http/http_api_server.hpp"
 #include "server/http/http_live_server.hpp"
 #include "server/http/https_live_server.hpp"
+#include "server/rtmp/rtmp_server.hpp"
+#include "server/rtmp/rtmps_server.hpp"
 #include "server/rtsp/rtsp_server.hpp"
 #include "server/rtsp/rtsps_server.hpp"
 #include "server/stun/stun_server.hpp"
 #include "server/webrtc/webrtc_server.hpp"
-#include "server/http/http_api_server.hpp"
-
-#include "service/dns/dns_service.hpp"
 #include "service/conn/http_conn_pools.h"
+#include "service/dns/dns_service.hpp"
+#include "version.h"
 
 using namespace mms;
 
-void wait_exit()
-{
+void wait_exit() {
     std::atomic_bool exit(false);
     boost::asio::io_context io;
     boost::asio::signal_set sigset(io, SIGINT, SIGTERM);
-    sigset.async_wait([&exit](const boost::system::error_code &err, int signal)
-                      { ((void)signal);((void)err);exit = true; });
+    sigset.async_wait([&exit](const boost::system::error_code &err, int signal) {
+        ((void)signal);
+        ((void)err);
+        exit = true;
+    });
 
     boost::system::error_code ec;
-    io.run(ec);
-    while (1)
-    {
-        if (exit)
-        {
+    io.run();
+    while (1) {
+        if (exit) {
             break;
         }
         sleep(1000);
@@ -53,11 +49,11 @@ void wait_exit()
 void init_log(bool is_debug_mode) {
     spdlog::set_level(spdlog::level::debug);
     Log::init(is_debug_mode);
-    CORE_INFO("Welcome to mms!"); 
+    CORE_INFO("Welcome to mms!");
 }
 
 void system_setup() {
-    struct rlimit rlim,rlim_new;
+    struct rlimit rlim, rlim_new;
     if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
         rlim_new.rlim_cur = rlim_new.rlim_max = RLIM_INFINITY;
         if (setrlimit(RLIMIT_NOFILE, &rlim_new) != 0) {
@@ -67,18 +63,15 @@ void system_setup() {
     }
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     system_setup();
     boost::program_options::variables_map vm;
     boost::program_options::options_description opts("all options");
     try {
-        opts.add_options()
-        ("version,v", "show the version")
-        ("config,c", boost::program_options::value<std::string>(), "the config file path")
-        ("help,h", "mms is a multi media server.")
-        ("debug,d", "output debug log to console.");
-        
+        opts.add_options()("version,v", "show the version")(
+            "config,c", boost::program_options::value<std::string>(), "the config file path")(
+            "help,h", "mms is a multi media server.")("debug,d", "output debug log to console.");
+
         boost::program_options::store(boost::program_options::parse_command_line(argc, argv, opts), vm);
         boost::program_options::notify(vm);
     } catch (std::exception &exp) {
@@ -96,22 +89,19 @@ int main(int argc, char *argv[])
 
     init_log(is_debug_mode);
 
-    if (vm.count("help"))
-    { //若参数中有help选项
+    if (vm.count("help")) {  // 若参数中有help选项
         std::cerr << opts << std::endl;
         return -1;
-    }
-    else
-    {
-        if (!vm.count("config"))
-        {
+    } else {
+        if (!vm.count("config")) {
             spdlog::error("please use -c option to set the config dir.");
             return -2;
         }
     }
 
     thread_pool_inst::get_mutable_instance().start(std::thread::hardware_concurrency());
-    HttpConnPools::get_instance().set_worker(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+    HttpConnPools::get_instance().set_worker(
+        thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
 
     std::string config_path = vm["config"].as<std::string>();
     auto config = Config::get_instance();
@@ -120,11 +110,11 @@ int main(int argc, char *argv[])
             spdlog::error("failed load config:{}, program exit!", config_path);
             return -3;
         }
-    } catch (std::exception & exp) {
+    } catch (std::exception &exp) {
         CORE_ERROR("load config failed, err:{}", exp.what());
         return -4;
     }
-    
+
     if (config->get_log_level() == "info") {
         spdlog::set_level(spdlog::level::info);
     } else if (config->get_log_level() == "debug") {
@@ -137,42 +127,46 @@ int main(int argc, char *argv[])
         spdlog::set_level(spdlog::level::warn);
     }
     // start dns service
-    DnsService & dns_service = DnsService::get_instance();
-    dns_service.start(); 
+    DnsService &dns_service = DnsService::get_instance();
+    dns_service.start();
     // start rtmp server
     std::shared_ptr<RtmpServer> rtmp_server;
     if (config->get_rtmp_config().is_enabled()) {
-        rtmp_server = std::make_shared<RtmpServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        rtmp_server =
+            std::make_shared<RtmpServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!rtmp_server->start(config->get_rtmp_config().port())) {
             CORE_ERROR("start rtmp server on port:{} failed", config->get_rtmp_config().port());
             return -1;
         }
         CORE_INFO("start rtmp server on port:{} succeed", config->get_rtmp_config().port());
     }
-    
+
     std::shared_ptr<RtmpsServer> rtmps_server;
     if (config->get_rtmps_config().is_enabled()) {
-        rtmps_server = std::make_shared<RtmpsServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        rtmps_server =
+            std::make_shared<RtmpsServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!rtmps_server->start(config->get_rtmps_config().port())) {
             CORE_ERROR("start rtmp server on port:{} failed", config->get_rtmps_config().port());
             return -1;
         }
         CORE_INFO("start rtmps server on port:{} succeed", config->get_rtmps_config().port());
     }
-    
+
     std::shared_ptr<HttpLiveServer> http_live_server;
     if (config->get_http_config().is_enabled()) {
-        http_live_server = std::make_shared<HttpLiveServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        http_live_server = std::make_shared<HttpLiveServer>(
+            thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!http_live_server->start(config->get_http_config().port())) {
             CORE_ERROR("start http live server on port:{} failed", config->get_http_config().port());
             return -3;
         }
         CORE_INFO("start http live server on port:{} succeed", config->get_http_config().port());
-    }    
+    }
 
     std::shared_ptr<HttpsLiveServer> https_live_server;
     if (config->get_https_config().is_enabled()) {
-        https_live_server = std::make_shared<HttpsLiveServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        https_live_server = std::make_shared<HttpsLiveServer>(
+            thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!https_live_server->start(config->get_https_config().port())) {
             CORE_ERROR("start https live server on port:{} failed", config->get_https_config().port());
             return -3;
@@ -182,7 +176,8 @@ int main(int argc, char *argv[])
 
     std::shared_ptr<RtspServer> rtsp_server;
     if (config->get_rtsp_config().is_enabled()) {
-        rtsp_server = std::make_shared<RtspServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
+        rtsp_server =
+            std::make_shared<RtspServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
         if (!rtsp_server->start(config->get_rtsp_config().port())) {
             CORE_ERROR("start rtsp server on port:{} failed", config->get_rtsp_config().port());
             return -3;
@@ -192,7 +187,8 @@ int main(int argc, char *argv[])
 
     std::shared_ptr<RtspsServer> rtsps_server;
     if (config->get_rtsps_config().is_enabled()) {
-        rtsps_server = std::make_shared<RtspsServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
+        rtsps_server =
+            std::make_shared<RtspsServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
         if (!rtsps_server->start(config->get_rtsps_config().port())) {
             CORE_ERROR("start rtsps server on port:{} failed", config->get_rtsps_config().port());
             return -3;
@@ -200,12 +196,13 @@ int main(int argc, char *argv[])
         CORE_INFO("start rtsps server on port:{} succeed", config->get_rtsps_config().port());
     }
 
-    auto & webrtc_config = config->get_webrtc_config();
+    auto &webrtc_config = config->get_webrtc_config();
     std::shared_ptr<WebRtcServer> webrtc_server;
     std::shared_ptr<StunServer> stun_server;
 
     if (webrtc_config.is_enabled()) {
-        stun_server = std::make_shared<StunServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        stun_server =
+            std::make_shared<StunServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!stun_server->start(webrtc_config.get_ip())) {
             CORE_ERROR("start webrtc stun server failed");
             return -6;
@@ -217,26 +214,29 @@ int main(int argc, char *argv[])
         } else {
             listen_ip = webrtc_config.get_ip();
         }
-        
-        webrtc_server = std::make_shared<WebRtcServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
+
+        webrtc_server =
+            std::make_shared<WebRtcServer>(thread_pool_inst::get_mutable_instance().get_all_workers());
         if (!webrtc_server->start(listen_ip, webrtc_config.get_ip(), webrtc_config.get_udp_port())) {
             CORE_ERROR("start webrtc server failed");
             return -7;
         }
-        CORE_INFO("start webrtc server succeed, listen ip:{}, udp port:{}", listen_ip, webrtc_config.get_udp_port());
+        CORE_INFO("start webrtc server succeed, listen ip:{}, udp port:{}", listen_ip,
+                  webrtc_config.get_udp_port());
     }
-    
+
     if (http_live_server && webrtc_server) {
         http_live_server->set_webrtc_server(webrtc_server);
     }
-    
+
     if (https_live_server && webrtc_server) {
         https_live_server->set_webrtc_server(webrtc_server);
     }
 
     std::shared_ptr<HttpApiServer> http_api_server;
     if (config->get_http_api_config().is_enabled()) {
-        http_api_server = std::make_shared<HttpApiServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
+        http_api_server =
+            std::make_shared<HttpApiServer>(thread_pool_inst::get_mutable_instance().get_worker(RAND_WORKER));
         if (!http_api_server->start(config->get_http_api_config().port())) {
             CORE_ERROR("start http api server on port:{} failed", config->get_http_api_config().port());
             return -3;
@@ -298,7 +298,7 @@ int main(int argc, char *argv[])
         CORE_INFO("stop http live server...");
         http_live_server->stop();
         CORE_INFO("stop http live server done");
-    }    
+    }
 
     thread_pool_inst::get_mutable_instance().stop();
     sleep(1);

--- a/live-server/server/http/http_flv_server_session.cpp
+++ b/live-server/server/http/http_flv_server_session.cpp
@@ -1,193 +1,204 @@
 #include "http_flv_server_session.hpp"
-#include "http_server_session.hpp"
-
-#include "core/rtmp_media_sink.hpp"
-#include "core/rtmp_media_source.hpp"
-#include "core/media_event.hpp"
-#include "core/source_manager.hpp"
-#include "core/flv_media_sink.hpp"
-#include "config/app_config.h"
 
 #include "app/app.h"
 #include "app/play_app.h"
 #include "app/publish_app.h"
-#include "config/cdn/origin_pull_config.h"
-#include "config/app_config.h"
 #include "bridge/media_bridge.hpp"
-
+#include "config/app_config.h"
+#include "config/cdn/origin_pull_config.h"
+#include "core/flv_media_sink.hpp"
+#include "core/media_event.hpp"
+#include "core/rtmp_media_sink.hpp"
+#include "core/rtmp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "http_server_session.hpp"
 #include "log/log.h"
 
+
 using namespace mms;
-HttpFlvServerSession::HttpFlvServerSession(std::shared_ptr<HttpRequest> http_req, std::shared_ptr<HttpResponse> http_resp) : StreamSession(http_resp->get_worker()), 
-                                                                                                                send_funcs_channel_(get_worker()->get_io_context()),
-                                                                                                                alive_timeout_timer_(get_worker()->get_io_context()),
-                                                                                                                wg_(get_worker()) {
+HttpFlvServerSession::HttpFlvServerSession(std::shared_ptr<HttpRequest> http_req,
+                                           std::shared_ptr<HttpResponse> http_resp)
+    : StreamSession(http_resp->get_worker()),
+      send_funcs_channel_(get_worker()->get_io_context()),
+      alive_timeout_timer_(get_worker()->get_io_context()),
+      wg_(get_worker()) {
     http_request_ = http_req;
     http_response_ = http_resp;
     send_bufs_.reserve(20);
     set_session_type("http-flv");
 }
 
-HttpFlvServerSession::~HttpFlvServerSession() {
-    CORE_DEBUG("destroy HttpFlvServerSession");
-}
+HttpFlvServerSession::~HttpFlvServerSession() { CORE_DEBUG("destroy HttpFlvServerSession"); }
 
 void HttpFlvServerSession::start_send_coroutine() {
     // 创建发送协程
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            auto send_func = co_await send_funcs_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                auto send_func = co_await send_funcs_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
+                }
+                update_active_timestamp();
+                bool ret = co_await send_func();
+                if (!ret) {
+                    break;
+                }
             }
-            update_active_timestamp();
-            bool ret = co_await send_func();
-            if (!ret) {
-                break;
-            }
-        }
-        
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        close(true);
-        wg_.done();
-    });
+
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            close(true);
+            wg_.done();
+        });
 }
 
 void HttpFlvServerSession::start_alive_checker() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            alive_timeout_timer_.expires_from_now(std::chrono::seconds(5));
-            co_await alive_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                co_return;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                alive_timeout_timer_.expires_after(std::chrono::seconds(5));
+                co_await alive_timeout_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    co_return;
+                }
+                int64_t now_ms = Utils::get_current_ms();
+                if (now_ms - last_active_time_ >= 50000) {  // 5秒没数据，超时
+                    co_return;
+                }
+                CORE_DEBUG("session:{} is alive", get_session_name());
             }
-            int64_t now_ms = Utils::get_current_ms();
-            if (now_ms - last_active_time_ >= 50000) {//5秒没数据，超时
-                co_return;
-            }
-            CORE_DEBUG("session:{} is alive", get_session_name());
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        close();
-        wg_.done();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            close();
+            wg_.done();
+        });
 }
 
-void HttpFlvServerSession::update_active_timestamp() {
-    last_active_time_ = Utils::get_current_ms();
-}
+void HttpFlvServerSession::update_active_timestamp() { last_active_time_ = Utils::get_current_ms(); }
 
 void HttpFlvServerSession::service() {
     CORE_INFO("start service HttpFlvServerSession");
     auto self(std::static_pointer_cast<HttpFlvServerSession>(shared_from_this()));
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        auto & query_params = http_request_->get_query_params();
-        for (auto & p : query_params) {
-            set_param(p.first, p.second);
-        }
-    
-        std::string domain = http_request_->get_query_param("domain");
-        if (domain.empty()) {
-            domain = http_request_->get_header("Host");
-            auto pos = domain.find(":");
-            if (pos != std::string::npos) {
-                domain = domain.substr(0, pos);
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            auto& query_params = http_request_->get_query_params();
+            for (auto& p : query_params) {
+                set_param(p.first, p.second);
             }
-        }
-        
-        set_session_info(domain, http_request_->get_path_param("app"), http_request_->get_path_param("stream"));
-        if (!find_and_set_app(domain_name_, app_name_, false)) {
-            CORE_ERROR("could not find config for domain:{}, app:{}", domain_name_, app_name_);
-            http_response_->add_header("Content-Type", "video/x-flv");
-            http_response_->add_header("Connection", "Close");
-            co_await http_response_->write_header(403, "Forbidden");
-            close(true);
-            co_return;
-        } 
 
-        auto play_app = std::static_pointer_cast<PlayApp>(get_app());
-        APP_TRACE(app_, "{}:{} play http-flv start", id_, session_name_);
-        CORE_DEBUG("{}:{} play http-flv start", id_, session_name_);
-        
-        auto err = co_await play_app->on_play(self);
-        if (err.code != 0) {
-            CORE_ERROR("play auth check failed, reason:{}", err.msg);
-            http_response_->add_header("Content-Type", "video/x-flv");
-            http_response_->add_header("Connection", "Close");
-            co_await http_response_->write_header(403, "Forbidden");
-            close(true);
-            co_return;
-        }
-        auto publish_app = play_app->get_publish_app();
-        // 1.本机查找
-        auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" + http_request_->get_path_param("stream");
-        auto source = SourceManager::get_instance().get_source(publish_app->get_domain_name(), get_app_name(), get_stream_name());
-        auto endpoint = this->get_param("mms-endpoint");
-        if (endpoint && endpoint.value().get() == "1") {
-            // if (!source) {
-            //     co_await MediaCenterClient::get_instance().notify_not_found(self);
-            //     http_response_->add_header("Content-Type", "video/x-flv");
-            //     http_response_->add_header("Connection", "Close");
-            //     co_await http_response_->write_header(404, "Not Found");
-            //     close();
-            //     co_return;
-            // }
-        }
-        
-        // 3. 本地配置查找外部回源
-        if (!source) {
-            source = co_await publish_app->find_media_source(self);
-        }
-        // 3. 到media center中心查找
-        // if (!source) {
-        //     source = co_await MediaCenterClient::get_instance().find_and_create_pull_media_source(self);
-        // }
-
-        if (!source) {
-            //真找不到源流了，应该是没在播
-            http_response_->add_header("Content-Type", "video/x-flv");
-            http_response_->add_header("Connection", "Close");
-            co_await http_response_->write_header(404, "Not Found");
-            close(true);
-            co_return;
-        }
-
-        // 判断是否需要进行桥转换
-        std::shared_ptr<MediaBridge> bridge;
-        if (source->get_media_type() != "flv") {// 尝试通过桥来创建
-            bridge = source->get_or_create_bridge(source->get_media_type() + "-flv", publish_app, stream_name_);
-            if (!bridge) {
-                http_response_->add_header("Connection", "close");
-                if (!(co_await http_response_->write_header(415, "Unsupported Media Type"))) {
+            std::string domain = http_request_->get_query_param("domain");
+            if (domain.empty()) {
+                domain = http_request_->get_header("Host");
+                auto pos = domain.find(":");
+                if (pos != std::string::npos) {
+                    domain = domain.substr(0, pos);
                 }
+            }
+
+            set_session_info(domain, http_request_->get_path_param("app"),
+                             http_request_->get_path_param("stream"));
+            if (!find_and_set_app(domain_name_, app_name_, false)) {
+                CORE_ERROR("could not find config for domain:{}, app:{}", domain_name_, app_name_);
+                http_response_->add_header("Content-Type", "video/x-flv");
+                http_response_->add_header("Connection", "Close");
+                co_await http_response_->write_header(403, "Forbidden");
                 close(true);
                 co_return;
             }
-            source = bridge->get_media_source();
-        }
 
-        flv_media_sink_ = std::make_shared<FlvMediaSink>(get_worker());
-        // 关闭flv
-        flv_media_sink_->on_close([this, self]() {
-            close();
-        });
-        // 事件处理
-        flv_media_sink_->set_on_source_status_changed_cb([this, self](SourceStatus status)->boost::asio::awaitable<void> {
-            co_return co_await process_source_status(status);
-        });
-        source->add_media_sink(flv_media_sink_);
-        co_return;
-    }, boost::asio::detached);
+            auto play_app = std::static_pointer_cast<PlayApp>(get_app());
+            APP_TRACE(app_, "{}:{} play http-flv start", id_, session_name_);
+            CORE_DEBUG("{}:{} play http-flv start", id_, session_name_);
+
+            auto err = co_await play_app->on_play(self);
+            if (err.code != 0) {
+                CORE_ERROR("play auth check failed, reason:{}", err.msg);
+                http_response_->add_header("Content-Type", "video/x-flv");
+                http_response_->add_header("Connection", "Close");
+                co_await http_response_->write_header(403, "Forbidden");
+                close(true);
+                co_return;
+            }
+            auto publish_app = play_app->get_publish_app();
+            // 1.本机查找
+            auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" +
+                               http_request_->get_path_param("stream");
+            auto source = SourceManager::get_instance().get_source(publish_app->get_domain_name(),
+                                                                   get_app_name(), get_stream_name());
+            auto endpoint = this->get_param("mms-endpoint");
+            if (endpoint && endpoint.value().get() == "1") {
+                // if (!source) {
+                //     co_await MediaCenterClient::get_instance().notify_not_found(self);
+                //     http_response_->add_header("Content-Type", "video/x-flv");
+                //     http_response_->add_header("Connection", "Close");
+                //     co_await http_response_->write_header(404, "Not Found");
+                //     close();
+                //     co_return;
+                // }
+            }
+
+            // 3. 本地配置查找外部回源
+            if (!source) {
+                source = co_await publish_app->find_media_source(self);
+            }
+            // 3. 到media center中心查找
+            // if (!source) {
+            //     source = co_await
+            //     MediaCenterClient::get_instance().find_and_create_pull_media_source(self);
+            // }
+
+            if (!source) {
+                // 真找不到源流了，应该是没在播
+                http_response_->add_header("Content-Type", "video/x-flv");
+                http_response_->add_header("Connection", "Close");
+                co_await http_response_->write_header(404, "Not Found");
+                close(true);
+                co_return;
+            }
+
+            // 判断是否需要进行桥转换
+            std::shared_ptr<MediaBridge> bridge;
+            if (source->get_media_type() != "flv") {  // 尝试通过桥来创建
+                bridge = source->get_or_create_bridge(source->get_media_type() + "-flv", publish_app,
+                                                      stream_name_);
+                if (!bridge) {
+                    http_response_->add_header("Connection", "close");
+                    if (!(co_await http_response_->write_header(415, "Unsupported Media Type"))) {
+                    }
+                    close(true);
+                    co_return;
+                }
+                source = bridge->get_media_source();
+            }
+
+            flv_media_sink_ = std::make_shared<FlvMediaSink>(get_worker());
+            // 关闭flv
+            flv_media_sink_->on_close([this, self]() { close(); });
+            // 事件处理
+            flv_media_sink_->set_on_source_status_changed_cb(
+                [this, self](SourceStatus status) -> boost::asio::awaitable<void> {
+                    co_return co_await process_source_status(status);
+                });
+            source->add_media_sink(flv_media_sink_);
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 boost::asio::awaitable<void> HttpFlvServerSession::process_source_status(SourceStatus status) {
@@ -195,7 +206,7 @@ boost::asio::awaitable<void> HttpFlvServerSession::process_source_status(SourceS
     if (status == E_SOURCE_STATUS_OK) {
         if (!has_send_http_header_) {
             has_send_http_header_ = true;
-            //找到源流，先发http送头部
+            // 找到源流，先发http送头部
             http_response_->add_header("Content-Type", "video/x-flv");
             http_response_->add_header("Connection", "Keep-Alive");
             http_response_->add_header("Access-Control-Allow-Origin", "*");
@@ -206,18 +217,22 @@ boost::asio::awaitable<void> HttpFlvServerSession::process_source_status(SourceS
         }
         // 发送完头部后，再开发送flv的tag
         start_send_coroutine();
-        flv_media_sink_->on_flv_tag([this, self](std::vector<std::shared_ptr<FlvTag>> & flv_tags)->boost::asio::awaitable<bool> {
-            boost::system::error_code ec;
-            if (flv_tags.size() <= 0) {
-                co_return true;
-            }
+        flv_media_sink_->on_flv_tag(
+            [this, self](std::vector<std::shared_ptr<FlvTag>>& flv_tags) -> boost::asio::awaitable<bool> {
+                boost::system::error_code ec;
+                if (flv_tags.size() <= 0) {
+                    co_return true;
+                }
 
-            co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&HttpFlvServerSession::send_flv_tags, this, flv_tags), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                co_return false;
-            }
-            co_return true;
-        });
+                co_await send_funcs_channel_.async_send(
+                    boost::system::error_code{},
+                    std::bind(&HttpFlvServerSession::send_flv_tags, this, flv_tags),
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    co_return false;
+                }
+                co_return true;
+            });
     } else if (status == E_SOURCE_STATUS_NOT_FOUND) {
         if (!has_send_http_header_) {
             has_send_http_header_ = true;
@@ -269,22 +284,23 @@ boost::asio::awaitable<void> HttpFlvServerSession::process_source_status(SourceS
 boost::asio::awaitable<bool> HttpFlvServerSession::send_flv_tags(std::vector<std::shared_ptr<FlvTag>> tags) {
     if (!has_write_flv_header_) {
         // 再发flv头部
-        auto source = flv_media_sink_->get_source();//SourceManager::get_instance().get_source(get_session_name());
+        auto source =
+            flv_media_sink_->get_source();  // SourceManager::get_instance().get_source(get_session_name());
         uint8_t flv_header[9];
         FlvHeader header;
-        header.flag.flags.audio = source->has_audio()?1:0;
-        header.flag.flags.video = source->has_video()?1:0;
+        header.flag.flags.audio = source->has_audio() ? 1 : 0;
+        header.flag.flags.video = source->has_video() ? 1 : 0;
         auto consumed = header.encode(flv_header, 9);
         if (!(co_await http_response_->write_data(std::string_view((char*)flv_header, consumed)))) {
             close(true);
             co_return false;
         }
         has_write_flv_header_ = true;
-    } 
+    }
 
     int i = 0;
     send_bufs_.clear();
-    for (auto & flv_tag : tags) {
+    for (auto& flv_tag : tags) {
         prev_tag_sizes_[i] = htonl(prev_tag_size_);
         send_bufs_.push_back(boost::asio::const_buffer((char*)&prev_tag_sizes_[i], sizeof(int32_t)));
         std::string_view tag_payload = flv_tag->get_using_data();
@@ -296,7 +312,7 @@ boost::asio::awaitable<bool> HttpFlvServerSession::send_flv_tags(std::vector<std
     if (send_bufs_.size() <= 0) {
         co_return true;
     }
-    
+
     if (!co_await http_response_->write_data(send_bufs_)) {
         close(true);
         co_return false;
@@ -304,7 +320,7 @@ boost::asio::awaitable<bool> HttpFlvServerSession::send_flv_tags(std::vector<std
     co_return true;
 }
 
-void HttpFlvServerSession::close(bool close_connection) {//如果是长连接，则不关闭socket
+void HttpFlvServerSession::close(bool close_connection) {  // 如果是长连接，则不关闭socket
     if (close_connection) {
         http_response_->close();
     }
@@ -318,25 +334,30 @@ void HttpFlvServerSession::close() {
         return;
     }
 
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        CORE_DEBUG("closing HttpFlvServerSession...");
-        send_funcs_channel_.close();
-        alive_timeout_timer_.cancel();
-        co_await wg_.wait();
-        
-        if (flv_media_sink_) {
-            auto source = flv_media_sink_->get_source();//SourceManager::get_instance().get_source(get_session_name());
-            if (source) {
-                source->remove_media_sink(flv_media_sink_);
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            CORE_DEBUG("closing HttpFlvServerSession...");
+            send_funcs_channel_.close();
+            alive_timeout_timer_.cancel();
+            co_await wg_.wait();
+
+            if (flv_media_sink_) {
+                auto source =
+                    flv_media_sink_
+                        ->get_source();  // SourceManager::get_instance().get_source(get_session_name());
+                if (source) {
+                    source->remove_media_sink(flv_media_sink_);
+                }
+
+                flv_media_sink_->close();
+                flv_media_sink_->on_close({});
+                flv_media_sink_->on_flv_tag({});
+                flv_media_sink_->set_on_source_status_changed_cb({});
+                flv_media_sink_ = nullptr;
             }
-            
-            flv_media_sink_->close();
-            flv_media_sink_->on_close({});
-            flv_media_sink_->on_flv_tag({});
-            flv_media_sink_->set_on_source_status_changed_cb({});
-            flv_media_sink_ = nullptr;
-        }
-        CORE_DEBUG("HttpFlvServerSession closed");
-        co_return;
-    }, boost::asio::detached);
+            CORE_DEBUG("HttpFlvServerSession closed");
+            co_return;
+        },
+        boost::asio::detached);
 }

--- a/live-server/server/http/http_m3u8_server_session.cpp
+++ b/live-server/server/http/http_m3u8_server_session.cpp
@@ -1,154 +1,162 @@
+#include "http_m3u8_server_session.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "http_m3u8_server_session.hpp"
+#include "app/play_app.h"
+#include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
-
-#include "core/ts_media_source.hpp"
+#include "bridge/media_bridge.hpp"
+#include "config/app_config.h"
 #include "core/hls_live_media_source.hpp"
 #include "core/source_manager.hpp"
-
+#include "core/ts_media_source.hpp"
 #include "protocol/http/http_request.hpp"
 #include "protocol/http/http_response.hpp"
 
-#include "core/source_manager.hpp"
-#include "app/play_app.h"
-#include "app/publish_app.h"
-#include "config/app_config.h"
-
-#include "bridge/media_bridge.hpp"
 
 using namespace mms;
 
-HttpM3u8ServerSession::HttpM3u8ServerSession(std::shared_ptr<HttpRequest> http_req, std::shared_ptr<HttpResponse> http_resp):StreamSession(http_resp->get_worker()) {
+HttpM3u8ServerSession::HttpM3u8ServerSession(std::shared_ptr<HttpRequest> http_req,
+                                             std::shared_ptr<HttpResponse> http_resp)
+    : StreamSession(http_resp->get_worker()) {
     http_request_ = http_req;
     http_response_ = http_resp;
 }
 
-HttpM3u8ServerSession::~HttpM3u8ServerSession() {
-}
+HttpM3u8ServerSession::~HttpM3u8ServerSession() {}
 
 void HttpM3u8ServerSession::service() {
     auto self(std::static_pointer_cast<HttpM3u8ServerSession>(this->shared_from_this()));
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        auto host = http_request_->get_header("Host");
-        auto pos = host.find_first_of(":");
-        if (pos != std::string::npos) {
-            host = host.substr(0, pos);
-        }
-
-        set_session_info(host, http_request_->get_path_param("app"), http_request_->get_path_param("stream"));
-        if (!find_and_set_app(domain_name_, app_name_, false)) {
-            CORE_DEBUG("could not find play app for domain:{}, app:{}", domain_name_, app_name_);
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(403, "Forbidden");
-            close();
-            co_return;
-        }
-
-        auto play_app = std::static_pointer_cast<PlayApp>(get_app());
-        auto publish_app = play_app->get_publish_app();
-        if (!publish_app) {
-            CORE_DEBUG("could not find publish app for domain:{}, app:{}", domain_name_, app_name_);
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(403, "Forbidden");
-            close();
-            co_return;
-        }
-        auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" + http_request_->get_path_param("stream");
-        // 1.本机查找
-        auto source = SourceManager::get_instance().get_source(publish_app->get_domain_name(), get_app_name(), get_stream_name());
-        if (!source) {// 2.本地配置查找外部回源
-            source = co_await publish_app->find_media_source(self);
-        }
-        // 3.到media center中心查找
-        // if (!source) {
-        //     source = co_await MediaCenterManager::get_instance().find_and_create_pull_media_source(self);
-        // }
-
-        std::shared_ptr<HlsLiveMediaSource> hls_source;
-        if (!source) {//todo : reply 404
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(404, "Not Found");
-            close();
-            co_return;
-        } else {
-            if (source->get_media_type() != "hls") {
-                auto ts_bridge = source->get_or_create_bridge(source->get_media_type() + "-ts", publish_app, stream_name_);
-                if (!ts_bridge) {
-                    http_response_->add_header("Connection", "close");
-                    http_response_->add_header("Content-Length", "0");
-                    http_response_->add_header("Access-Control-Allow-Origin", "*");
-                    co_await http_response_->write_header(415, "Unsupported Media Type");
-                    close();
-                    co_return;
-                }
-
-                auto ts_source = std::static_pointer_cast<TsMediaSource>(ts_bridge->get_media_source());
-                auto hls_bridge = ts_source->get_or_create_bridge(ts_source->get_media_type() + "-hls", publish_app, stream_name_);
-                if (!hls_bridge) {
-                    http_response_->add_header("Connection", "close");
-                    http_response_->add_header("Content-Length", "0");
-                    http_response_->add_header("Access-Control-Allow-Origin", "*");
-                    co_await http_response_->write_header(415, "Unsupported Media Type");
-                    close();
-                    co_return;
-                }
-                hls_source = std::static_pointer_cast<HlsLiveMediaSource>(hls_bridge->get_media_source());
-                hls_source->set_source_info(publish_app->get_domain_name(), app_name_, stream_name_);
-            } else {
-                hls_source = std::static_pointer_cast<HlsLiveMediaSource>(source);
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            auto host = http_request_->get_header("Host");
+            auto pos = host.find_first_of(":");
+            if (pos != std::string::npos) {
+                host = host.substr(0, pos);
             }
 
-            int try_count = 0;
-            while (try_count <= 400) {
-                hls_source->update_last_access_time();
-                auto status = hls_source->get_status();
-                bool ret = co_await process_source_status(status);
-                if (!ret) {
-                    close();
-                    co_return;
-                }
-
-                std::string m3u8 = hls_source->get_m3u8();
-                if (m3u8.empty()) {
-                    try_count++;
-                    boost::system::error_code ec;
-                    boost::asio::steady_timer timer(worker_->get_io_context());
-                    timer.expires_from_now(std::chrono::milliseconds(100));
-                    co_await timer.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                    continue;
-                }
-
+            set_session_info(host, http_request_->get_path_param("app"),
+                             http_request_->get_path_param("stream"));
+            if (!find_and_set_app(domain_name_, app_name_, false)) {
+                CORE_DEBUG("could not find play app for domain:{}, app:{}", domain_name_, app_name_);
                 http_response_->add_header("Connection", "close");
-                http_response_->add_header("Content-Type", "application/vnd.apple.mpegurl");
-                http_response_->add_header("Content-Length", std::to_string(m3u8.size()));
+                http_response_->add_header("Content-Length", "0");
                 http_response_->add_header("Access-Control-Allow-Origin", "*");
-                if (!(co_await http_response_->write_header(200, "OK"))) {
-                    close();
-                    co_return;
-                }
-                co_await http_response_->write_data((uint8_t*)m3u8.data(), m3u8.size());
+                co_await http_response_->write_header(403, "Forbidden");
+                close();
                 co_return;
             }
 
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(404, "Not Found");
-            close();
-        }
+            auto play_app = std::static_pointer_cast<PlayApp>(get_app());
+            auto publish_app = play_app->get_publish_app();
+            if (!publish_app) {
+                CORE_DEBUG("could not find publish app for domain:{}, app:{}", domain_name_, app_name_);
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Content-Length", "0");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(403, "Forbidden");
+                close();
+                co_return;
+            }
+            auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" +
+                               http_request_->get_path_param("stream");
+            // 1.本机查找
+            auto source = SourceManager::get_instance().get_source(publish_app->get_domain_name(),
+                                                                   get_app_name(), get_stream_name());
+            if (!source) {  // 2.本地配置查找外部回源
+                source = co_await publish_app->find_media_source(self);
+            }
+            // 3.到media center中心查找
+            // if (!source) {
+            //     source = co_await
+            //     MediaCenterManager::get_instance().find_and_create_pull_media_source(self);
+            // }
 
-        co_return;
-    }, boost::asio::detached);
+            std::shared_ptr<HlsLiveMediaSource> hls_source;
+            if (!source) {  // todo : reply 404
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Content-Length", "0");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(404, "Not Found");
+                close();
+                co_return;
+            } else {
+                if (source->get_media_type() != "hls") {
+                    auto ts_bridge = source->get_or_create_bridge(source->get_media_type() + "-ts",
+                                                                  publish_app, stream_name_);
+                    if (!ts_bridge) {
+                        http_response_->add_header("Connection", "close");
+                        http_response_->add_header("Content-Length", "0");
+                        http_response_->add_header("Access-Control-Allow-Origin", "*");
+                        co_await http_response_->write_header(415, "Unsupported Media Type");
+                        close();
+                        co_return;
+                    }
+
+                    auto ts_source = std::static_pointer_cast<TsMediaSource>(ts_bridge->get_media_source());
+                    auto hls_bridge = ts_source->get_or_create_bridge(ts_source->get_media_type() + "-hls",
+                                                                      publish_app, stream_name_);
+                    if (!hls_bridge) {
+                        http_response_->add_header("Connection", "close");
+                        http_response_->add_header("Content-Length", "0");
+                        http_response_->add_header("Access-Control-Allow-Origin", "*");
+                        co_await http_response_->write_header(415, "Unsupported Media Type");
+                        close();
+                        co_return;
+                    }
+                    hls_source = std::static_pointer_cast<HlsLiveMediaSource>(hls_bridge->get_media_source());
+                    hls_source->set_source_info(publish_app->get_domain_name(), app_name_, stream_name_);
+                } else {
+                    hls_source = std::static_pointer_cast<HlsLiveMediaSource>(source);
+                }
+
+                int try_count = 0;
+                while (try_count <= 400) {
+                    hls_source->update_last_access_time();
+                    auto status = hls_source->get_status();
+                    bool ret = co_await process_source_status(status);
+                    if (!ret) {
+                        close();
+                        co_return;
+                    }
+
+                    std::string m3u8 = hls_source->get_m3u8();
+                    if (m3u8.empty()) {
+                        try_count++;
+                        boost::system::error_code ec;
+                        boost::asio::steady_timer timer(worker_->get_io_context());
+                        timer.expires_after(std::chrono::milliseconds(100));
+                        co_await timer.async_wait(
+                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                        continue;
+                    }
+
+                    http_response_->add_header("Connection", "close");
+                    http_response_->add_header("Content-Type", "application/vnd.apple.mpegurl");
+                    http_response_->add_header("Content-Length", std::to_string(m3u8.size()));
+                    http_response_->add_header("Access-Control-Allow-Origin", "*");
+                    if (!(co_await http_response_->write_header(200, "OK"))) {
+                        close();
+                        co_return;
+                    }
+                    co_await http_response_->write_data((uint8_t*)m3u8.data(), m3u8.size());
+                    co_return;
+                }
+
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(404, "Not Found");
+                close();
+            }
+
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 boost::asio::awaitable<bool> HttpM3u8ServerSession::process_source_status(SourceStatus status) {

--- a/live-server/server/http/http_mpd_server_session.cpp
+++ b/live-server/server/http/http_mpd_server_session.cpp
@@ -1,152 +1,161 @@
+#include "http_mpd_server_session.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "http_mpd_server_session.hpp"
+#include "app/play_app.h"
+#include "app/publish_app.h"
 #include "base/thread/thread_worker.hpp"
-
+#include "bridge/media_bridge.hpp"
+#include "config/app_config.h"
 #include "core/mp4_media_source.hpp"
 #include "core/mpd_live_media_source.hpp"
 #include "core/source_manager.hpp"
-
 #include "protocol/http/http_request.hpp"
 #include "protocol/http/http_response.hpp"
 
-#include "core/source_manager.hpp"
-#include "app/play_app.h"
-#include "app/publish_app.h"
-#include "config/app_config.h"
-
-#include "bridge/media_bridge.hpp"
 
 using namespace mms;
 
-HttpMpdServerSession::HttpMpdServerSession(std::shared_ptr<HttpRequest> http_req, std::shared_ptr<HttpResponse> http_resp):StreamSession(http_resp->get_worker()) {
+HttpMpdServerSession::HttpMpdServerSession(std::shared_ptr<HttpRequest> http_req,
+                                           std::shared_ptr<HttpResponse> http_resp)
+    : StreamSession(http_resp->get_worker()) {
     http_request_ = http_req;
     http_response_ = http_resp;
 }
 
-HttpMpdServerSession::~HttpMpdServerSession() {
-}
+HttpMpdServerSession::~HttpMpdServerSession() {}
 
 void HttpMpdServerSession::service() {
     auto self(std::static_pointer_cast<HttpMpdServerSession>(this->shared_from_this()));
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        auto host = http_request_->get_header("Host");
-        auto pos = host.find_first_of(":");
-        if (pos != std::string::npos) {
-            host = host.substr(0, pos);
-        }
-
-        set_session_info(host, http_request_->get_path_param("app"), http_request_->get_path_param("stream"));
-        if (!find_and_set_app(domain_name_, app_name_, false)) {
-            CORE_DEBUG("could not find play app for domain:{}, app:{}", domain_name_, app_name_);
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(403, "Forbidden");
-            close();
-            co_return;
-        }
-
-        auto play_app = std::static_pointer_cast<PlayApp>(get_app());
-        auto publish_app = play_app->get_publish_app();
-        if (!publish_app) {
-            CORE_DEBUG("could not find publish app for domain:{}, app:{}", domain_name_, app_name_);
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(403, "Forbidden");
-            close();
-            co_return;
-        }
-        auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" + http_request_->get_path_param("stream");
-        // 1.本机查找
-        auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
-        if (!source) {// 2.本地配置查找外部回源
-            source = co_await publish_app->find_media_source(self);
-        }
-        // 3.到media center中心查找
-        // if (!source) {
-        //     source = co_await MediaCenterManager::get_instance().find_and_create_pull_media_source(self);
-        // }
-
-        std::shared_ptr<MpdLiveMediaSource> mpd_source;
-        if (!source) {//todo : reply 404
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(404, "Not Found");
-            close();
-            co_return;
-        } else {
-            if (source->get_media_type() != "mpd") {
-                auto mp4_bridge = source->get_or_create_bridge(source->get_media_type() + "-mp4", publish_app, stream_name_);
-                if (!mp4_bridge) {
-                    http_response_->add_header("Connection", "close");
-                    http_response_->add_header("Content-Length", "0");
-                    http_response_->add_header("Access-Control-Allow-Origin", "*");
-                    co_await http_response_->write_header(415, "Unsupported Media Type");
-                    close();
-                    co_return;
-                }
-
-                auto mp4_source = std::static_pointer_cast<Mp4MediaSource>(mp4_bridge->get_media_source());
-                if (!mp4_source) {
-                    close();
-                    co_return;
-                }
-                auto mpd_bridge = mp4_source->get_or_create_bridge(mp4_source->get_media_type() + "-mpd", publish_app, stream_name_);
-                if (!mpd_bridge) {
-                    http_response_->add_header("Connection", "close");
-                    http_response_->add_header("Content-Length", "0");
-                    http_response_->add_header("Access-Control-Allow-Origin", "*");
-                    co_await http_response_->write_header(415, "Unsupported Media Type");
-                    close();
-                    co_return;
-                }
-                mpd_source = std::static_pointer_cast<MpdLiveMediaSource>(mpd_bridge->get_media_source());
-                mpd_source->set_source_info(domain_name_, app_name_, stream_name_);
-            } else {
-                mpd_source = std::static_pointer_cast<MpdLiveMediaSource>(source);
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            auto host = http_request_->get_header("Host");
+            auto pos = host.find_first_of(":");
+            if (pos != std::string::npos) {
+                host = host.substr(0, pos);
             }
 
-            int try_count = 0;
-            while (try_count <= 400) {
-                mpd_source->update_last_access_time();
-                std::string mpd = mpd_source->get_mpd();
-                if (mpd.empty()) {
-                    try_count++;
-                    boost::system::error_code ec;
-                    boost::asio::steady_timer timer(worker_->get_io_context());
-                    timer.expires_from_now(std::chrono::milliseconds(100));
-                    co_await timer.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                    continue;
-                }
-
+            set_session_info(host, http_request_->get_path_param("app"),
+                             http_request_->get_path_param("stream"));
+            if (!find_and_set_app(domain_name_, app_name_, false)) {
+                CORE_DEBUG("could not find play app for domain:{}, app:{}", domain_name_, app_name_);
                 http_response_->add_header("Connection", "close");
-                http_response_->add_header("Content-Type", "application/dash+xml");
-                http_response_->add_header("Content-Length", std::to_string(mpd.size()));
+                http_response_->add_header("Content-Length", "0");
                 http_response_->add_header("Access-Control-Allow-Origin", "*");
-                if (!(co_await http_response_->write_header(200, "OK"))) {
-                    close();
-                    co_return;
-                }
-                co_await http_response_->write_data((uint8_t*)mpd.data(), mpd.size());
+                co_await http_response_->write_header(403, "Forbidden");
+                close();
                 co_return;
             }
 
-            http_response_->add_header("Connection", "close");
-            http_response_->add_header("Content-Length", "0");
-            http_response_->add_header("Access-Control-Allow-Origin", "*");
-            co_await http_response_->write_header(404, "Not Found");
-            close();
-        }
+            auto play_app = std::static_pointer_cast<PlayApp>(get_app());
+            auto publish_app = play_app->get_publish_app();
+            if (!publish_app) {
+                CORE_DEBUG("could not find publish app for domain:{}, app:{}", domain_name_, app_name_);
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Content-Length", "0");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(403, "Forbidden");
+                close();
+                co_return;
+            }
+            auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" +
+                               http_request_->get_path_param("stream");
+            // 1.本机查找
+            auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(),
+                                                                   get_stream_name());
+            if (!source) {  // 2.本地配置查找外部回源
+                source = co_await publish_app->find_media_source(self);
+            }
+            // 3.到media center中心查找
+            // if (!source) {
+            //     source = co_await
+            //     MediaCenterManager::get_instance().find_and_create_pull_media_source(self);
+            // }
 
-        co_return;
-    }, boost::asio::detached);
+            std::shared_ptr<MpdLiveMediaSource> mpd_source;
+            if (!source) {  // todo : reply 404
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Content-Length", "0");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(404, "Not Found");
+                close();
+                co_return;
+            } else {
+                if (source->get_media_type() != "mpd") {
+                    auto mp4_bridge = source->get_or_create_bridge(source->get_media_type() + "-mp4",
+                                                                   publish_app, stream_name_);
+                    if (!mp4_bridge) {
+                        http_response_->add_header("Connection", "close");
+                        http_response_->add_header("Content-Length", "0");
+                        http_response_->add_header("Access-Control-Allow-Origin", "*");
+                        co_await http_response_->write_header(415, "Unsupported Media Type");
+                        close();
+                        co_return;
+                    }
+
+                    auto mp4_source =
+                        std::static_pointer_cast<Mp4MediaSource>(mp4_bridge->get_media_source());
+                    if (!mp4_source) {
+                        close();
+                        co_return;
+                    }
+                    auto mpd_bridge = mp4_source->get_or_create_bridge(mp4_source->get_media_type() + "-mpd",
+                                                                       publish_app, stream_name_);
+                    if (!mpd_bridge) {
+                        http_response_->add_header("Connection", "close");
+                        http_response_->add_header("Content-Length", "0");
+                        http_response_->add_header("Access-Control-Allow-Origin", "*");
+                        co_await http_response_->write_header(415, "Unsupported Media Type");
+                        close();
+                        co_return;
+                    }
+                    mpd_source = std::static_pointer_cast<MpdLiveMediaSource>(mpd_bridge->get_media_source());
+                    mpd_source->set_source_info(domain_name_, app_name_, stream_name_);
+                } else {
+                    mpd_source = std::static_pointer_cast<MpdLiveMediaSource>(source);
+                }
+
+                int try_count = 0;
+                while (try_count <= 400) {
+                    mpd_source->update_last_access_time();
+                    std::string mpd = mpd_source->get_mpd();
+                    if (mpd.empty()) {
+                        try_count++;
+                        boost::system::error_code ec;
+                        boost::asio::steady_timer timer(worker_->get_io_context());
+                        timer.expires_after(std::chrono::milliseconds(100));
+                        co_await timer.async_wait(
+                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                        continue;
+                    }
+
+                    http_response_->add_header("Connection", "close");
+                    http_response_->add_header("Content-Type", "application/dash+xml");
+                    http_response_->add_header("Content-Length", std::to_string(mpd.size()));
+                    http_response_->add_header("Access-Control-Allow-Origin", "*");
+                    if (!(co_await http_response_->write_header(200, "OK"))) {
+                        close();
+                        co_return;
+                    }
+                    co_await http_response_->write_data((uint8_t*)mpd.data(), mpd.size());
+                    co_return;
+                }
+
+                http_response_->add_header("Connection", "close");
+                http_response_->add_header("Content-Length", "0");
+                http_response_->add_header("Access-Control-Allow-Origin", "*");
+                co_await http_response_->write_header(404, "Not Found");
+                close();
+            }
+
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 void HttpMpdServerSession::close() {

--- a/live-server/server/rtsp/rtsp_server_session.cpp
+++ b/live-server/server/rtsp/rtsp_server_session.cpp
@@ -1,172 +1,176 @@
+#include "rtsp_server_session.hpp"
+
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
-#include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-#include "log/log.h"
-
-#include "base/network/socket_interface.hpp"
-#include "rtsp_server_session.hpp"
-#include "server/session.hpp"
-#include "protocol/rtsp/rtsp_request.hpp"
-#include "protocol/rtsp/rtsp_response.hpp"
-
-#include "core/rtsp_media_source.hpp"
-#include "core/rtsp_media_sink.hpp"
-
-#include "core/source_manager.hpp" 
-
-#include "config/config.h"
 #include "app/play_app.h"
 #include "app/publish_app.h"
-
+#include "base/network/socket_interface.hpp"
+#include "base/utils/utils.h"
+#include "bridge/media_bridge.hpp"
+#include "config/app_config.h"
+#include "config/config.h"
+#include "core/rtsp_media_sink.hpp"
+#include "core/rtsp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "log/log.h"
+#include "protocol/rtsp/rtsp_request.hpp"
+#include "protocol/rtsp/rtsp_response.hpp"
 #include "protocol/sdp/sdp.hpp"
 #include "rtp_over_tcp_pkt.hpp"
-#include "config/app_config.h"
-#include "core/source_manager.hpp"
+#include "server/session.hpp"
 
-#include "bridge/media_bridge.hpp"
-
-#include "base/utils/utils.h"
 using namespace mms;
-RtspServerSession::RtspServerSession(std::shared_ptr<SocketInterface> sock):StreamSession(sock->get_worker()), sock_(sock),
-                                                       send_funcs_channel_(sock->get_worker()->get_io_context(), 2048),
-                                                       play_sdp_timeout_timer_(sock->get_worker()->get_io_context()),
-                                                       wg_(worker_) {
+RtspServerSession::RtspServerSession(std::shared_ptr<SocketInterface> sock)
+    : StreamSession(sock->get_worker()),
+      sock_(sock),
+      send_funcs_channel_(sock->get_worker()->get_io_context(), 2048),
+      play_sdp_timeout_timer_(sock->get_worker()->get_io_context()),
+      wg_(worker_) {
     set_session_type("rtsp");
     recv_buf_ = std::make_unique<char[]>(RTSP_MAX_BUF);
     send_buf_ = std::make_unique<char[]>(RTSP_MAX_BUF);
     session_id_ = Utils::get_rand64();
 }
 
-RtspServerSession::~RtspServerSession() {
-    CORE_DEBUG("destroy RtspServerSession:{}", get_session_name());
-}
+RtspServerSession::~RtspServerSession() { CORE_DEBUG("destroy RtspServerSession:{}", get_session_name()); }
 
 void RtspServerSession::start_recv_coroutine() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(sock_->get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        int32_t consumed = 0;
-        while (1) {
-            if (RTSP_MAX_BUF - recv_buf_size_ <= 0) {
-                break;
-            }
+    boost::asio::co_spawn(
+        sock_->get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            int32_t consumed = 0;
+            while (1) {
+                if (RTSP_MAX_BUF - recv_buf_size_ <= 0) {
+                    break;
+                }
 
-            auto recv_size = co_await sock_->recv_some((uint8_t*)recv_buf_.get() + recv_buf_size_, RTSP_MAX_BUF - recv_buf_size_);
-            if (recv_size < 0) {//response error
-                break;
-            }
-            
-            recv_buf_size_ += recv_size;
-            
-            do {
-                consumed = 0;
-                std::string_view buf(recv_buf_.get(), recv_buf_size_);
-                if (buf.starts_with("RTSP")) {//response
-                    if (!rtsp_response_) {
-                        rtsp_response_ = std::make_shared<RtspResponse>();
-                    }
-                    consumed = rtsp_response_->parse(buf);
-                    if (consumed <= 0) {
-                        break;
-                    }
-                    recv_buf_size_ -= consumed;
-                    memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
-                    std::shared_ptr<RtspResponse> resp = std::move(rtsp_response_);
-                    co_await on_rtsp_response(resp);
-                } else if (buf.starts_with("$")) {//rtp or rtcp
-                    if (!is_tcp_transport_) {
-                        std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
-                        resp->add_header("Connection", "Close");
-                        resp->set_status(RTSP_STATUS_CODE_NOT_ACCEPTABLE, "Not Acceptable");
-                        std::string resp_data = resp->to_string();
-                        auto ret = co_await sock_->send((const uint8_t*)resp_data.data(), resp_data.size());
-                        if (!ret) {//todo: add log
+                auto recv_size = co_await sock_->recv_some((uint8_t *)recv_buf_.get() + recv_buf_size_,
+                                                           RTSP_MAX_BUF - recv_buf_size_);
+                if (recv_size < 0) {  // response error
+                    break;
+                }
+
+                recv_buf_size_ += recv_size;
+
+                do {
+                    consumed = 0;
+                    std::string_view buf(recv_buf_.get(), recv_buf_size_);
+                    if (buf.starts_with("RTSP")) {  // response
+                        if (!rtsp_response_) {
+                            rtsp_response_ = std::make_shared<RtspResponse>();
+                        }
+                        consumed = rtsp_response_->parse(buf);
+                        if (consumed <= 0) {
+                            break;
+                        }
+                        recv_buf_size_ -= consumed;
+                        memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
+                        std::shared_ptr<RtspResponse> resp = std::move(rtsp_response_);
+                        co_await on_rtsp_response(resp);
+                    } else if (buf.starts_with("$")) {  // rtp or rtcp
+                        if (!is_tcp_transport_) {
+                            std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
+                            resp->add_header("Connection", "Close");
+                            resp->set_status(RTSP_STATUS_CODE_NOT_ACCEPTABLE, "Not Acceptable");
+                            std::string resp_data = resp->to_string();
+                            auto ret =
+                                co_await sock_->send((const uint8_t *)resp_data.data(), resp_data.size());
+                            if (!ret) {  // todo: add log
+                                co_return;
+                            }
                             co_return;
                         }
-                        co_return;
-                    }
 
-                    RtpOverTcpPktHeader rtp_over_tcp_pkt_header;
-                    auto consumed1 = rtp_over_tcp_pkt_header.decode((uint8_t*)recv_buf_.get(), recv_buf_size_);
-                    if (consumed1 <= 0) {
-                        break;
-                    }
+                        RtpOverTcpPktHeader rtp_over_tcp_pkt_header;
+                        auto consumed1 =
+                            rtp_over_tcp_pkt_header.decode((uint8_t *)recv_buf_.get(), recv_buf_size_);
+                        if (consumed1 <= 0) {
+                            break;
+                        }
 
-                    if (recv_buf_size_ - consumed1 < rtp_over_tcp_pkt_header.get_pkt_len()) {
-                        break;
-                    }
+                        if (recv_buf_size_ - consumed1 < rtp_over_tcp_pkt_header.get_pkt_len()) {
+                            break;
+                        }
 
-                    auto pt = RtpHeader::parse_pt((uint8_t*)recv_buf_.get() + consumed1, recv_buf_size_ - consumed1);//todo 改成用ssrc来区分
-                    int32_t consumed2 = 0;
-                    if (rtp_over_tcp_pkt_header.get_channel()%2 == 0) {
-                        if (pt == rtsp_media_source_->get_video_pt()) {
-                            std::shared_ptr<RtpPacket> video_pkt = std::make_shared<RtpPacket>();
-                            consumed2 = video_pkt->decode_and_store((uint8_t*)recv_buf_.get() + consumed1, rtp_over_tcp_pkt_header.get_pkt_len());
-                            if (consumed2 < 0)
-                            {
-                                co_return;
+                        auto pt = RtpHeader::parse_pt((uint8_t *)recv_buf_.get() + consumed1,
+                                                      recv_buf_size_ - consumed1);  // todo 改成用ssrc来区分
+                        int32_t consumed2 = 0;
+                        if (rtp_over_tcp_pkt_header.get_channel() % 2 == 0) {
+                            if (pt == rtsp_media_source_->get_video_pt()) {
+                                std::shared_ptr<RtpPacket> video_pkt = std::make_shared<RtpPacket>();
+                                consumed2 =
+                                    video_pkt->decode_and_store((uint8_t *)recv_buf_.get() + consumed1,
+                                                                rtp_over_tcp_pkt_header.get_pkt_len());
+                                if (consumed2 < 0) {
+                                    co_return;
+                                }
+                                std::vector<std::shared_ptr<RtpPacket>> pkts = {video_pkt};
+                                co_await rtsp_media_source_->on_video_packets(pkts);
+                            } else if (pt == rtsp_media_source_->get_audio_pt()) {
+                                std::shared_ptr<RtpPacket> audio_pkt = std::make_shared<RtpPacket>();
+                                consumed2 =
+                                    audio_pkt->decode_and_store((uint8_t *)recv_buf_.get() + consumed1,
+                                                                rtp_over_tcp_pkt_header.get_pkt_len());
+                                if (consumed2 < 0) {
+                                    co_return;
+                                }
+
+                                std::vector<std::shared_ptr<RtpPacket>> pkts = {audio_pkt};
+                                co_await rtsp_media_source_->on_audio_packets(pkts);
+                            } else {
                             }
-                            std::vector<std::shared_ptr<RtpPacket>> pkts = {video_pkt};
-                            co_await rtsp_media_source_->on_video_packets(pkts);
-                        } else if (pt == rtsp_media_source_->get_audio_pt()) {
-                            std::shared_ptr<RtpPacket> audio_pkt = std::make_shared<RtpPacket>();
-                            consumed2 = audio_pkt->decode_and_store((uint8_t*)recv_buf_.get() + consumed1, rtp_over_tcp_pkt_header.get_pkt_len());
-                            if (consumed2 < 0)
-                            {
-                                co_return;
-                            }
-                            
-                            std::vector<std::shared_ptr<RtpPacket>> pkts = {audio_pkt};
-                            co_await rtsp_media_source_->on_audio_packets(pkts);
+                        }
+
+                        consumed = consumed1 + rtp_over_tcp_pkt_header.get_pkt_len();
+                        recv_buf_size_ -= consumed;
+                        memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
+                    } else {  // request
+                        if (!rtsp_request_) {
+                            rtsp_request_ = std::make_shared<RtspRequest>();
                         } else {
+                            rtsp_request_->clear();
+                        }
 
+                        consumed = rtsp_request_->parse(buf);
+                        if (consumed <= 0) {  // error
+                            break;
+                        }
+                        recv_buf_size_ -= consumed;
+                        memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
+                        std::shared_ptr<RtspRequest> req = std::move(rtsp_request_);
+                        if (!co_await on_rtsp_request(req)) {
+                            co_return;
                         }
                     }
-
-                    consumed = consumed1 + rtp_over_tcp_pkt_header.get_pkt_len();
-                    recv_buf_size_ -= consumed;
-                    memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
-                } else {//request
-                    if (!rtsp_request_) {
-                        rtsp_request_ = std::make_shared<RtspRequest>();
-                    } else {
-                        rtsp_request_->clear();
-                    }
-
-                    consumed = rtsp_request_->parse(buf);
-                    if (consumed <= 0) {//error
-                        break;
-                    }
-                    recv_buf_size_ -= consumed;
-                    memmove(recv_buf_.get(), recv_buf_.get() + consumed, recv_buf_size_);
-                    std::shared_ptr<RtspRequest> req = std::move(rtsp_request_);
-                    if (!co_await on_rtsp_request(req)) {
+                } while (recv_buf_size_ > 0 && consumed > 0);
+                // 出错，response 4xx错误
+                if (consumed < 0) {
+                    boost::system::error_code ec;
+                    std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
+                    resp->add_header("Connection", "Close");
+                    resp->set_status(RTSP_STATUS_CODE_NOT_ACCEPTABLE, "Not Acceptable");
+                    co_await send_funcs_channel_.async_send(
+                        boost::system::error_code{},
+                        std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                        boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                    if (ec) {
                         co_return;
                     }
                 }
             }
-            while (recv_buf_size_ > 0 && consumed > 0);
-            //出错，response 4xx错误
-            if (consumed < 0) {
-                boost::system::error_code ec;
-                std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
-                resp->add_header("Connection", "Close");
-                resp->set_status(RTSP_STATUS_CODE_NOT_ACCEPTABLE, "Not Acceptable");
-                co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
-                    co_return;
-                }
-            }
-        }
-        
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        close();
-        wg_.done();
-    });
+
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            close();
+            wg_.done();
+        });
 }
 
 void RtspServerSession::service() {
@@ -176,36 +180,41 @@ void RtspServerSession::service() {
     start_recv_coroutine();
     // 启动发送协程
     wg_.add(1);
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            auto send_func = co_await send_funcs_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                auto send_func = co_await send_funcs_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
+                }
 
-            bool ret = co_await send_func();
-            if (!ret) {
-                co_return;
+                bool ret = co_await send_func();
+                if (!ret) {
+                    co_return;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
 boost::asio::awaitable<bool> RtspServerSession::send_rtsp_resp(std::shared_ptr<RtspResponse> rtsp_resp) {
     std::string resp_data = rtsp_resp->to_string();
-    if (!co_await sock_->send((const uint8_t*)resp_data.data(), resp_data.size())) {
+    if (!co_await sock_->send((const uint8_t *)resp_data.data(), resp_data.size())) {
         co_return false;
     }
     co_return true;
 }
 
-boost::asio::awaitable<bool> RtspServerSession::send_rtp_over_tcp_pkts(std::vector<std::shared_ptr<RtpPacket>> rtp_pkts) {
+boost::asio::awaitable<bool> RtspServerSession::send_rtp_over_tcp_pkts(
+    std::vector<std::shared_ptr<RtpPacket>> rtp_pkts) {
     if (!is_tcp_transport_ || !rtsp_media_sink_) {
         co_return false;
     }
@@ -220,15 +229,15 @@ boost::asio::awaitable<bool> RtspServerSession::send_rtp_over_tcp_pkts(std::vect
         uint8_t header[20];
         RtpOverTcpPktHeader rtp_over_tcp_pkt_header;
         rtp_over_tcp_pkt_header.set_channel(channel);
-        
-        auto rtp_size = rtp_pkt->encode((uint8_t*)send_buf_.get(), RTSP_MAX_BUF);
+
+        auto rtp_size = rtp_pkt->encode((uint8_t *)send_buf_.get(), RTSP_MAX_BUF);
         rtp_over_tcp_pkt_header.set_pkt_len(rtp_size);
-        auto header_size = rtp_over_tcp_pkt_header.encode((uint8_t*)header, 20);
+        auto header_size = rtp_over_tcp_pkt_header.encode((uint8_t *)header, 20);
         if (!co_await sock_->send(header, header_size)) {
             co_return false;
         }
 
-        if (!co_await sock_->send((uint8_t*)send_buf_.get(), rtp_size)) {
+        if (!co_await sock_->send((uint8_t *)send_buf_.get(), rtp_size)) {
             co_return false;
         }
     }
@@ -240,42 +249,47 @@ void RtspServerSession::close() {
         return;
     }
     auto self(this->shared_from_this());
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        CORE_DEBUG("closing rtsp sever session:{}", get_session_name());
-        boost::system::error_code ec;
-        if (sock_) {
-            sock_->close();
-        }
-
-        send_funcs_channel_.close();
-        co_await wg_.wait();
-        
-        if (rtsp_media_source_) {
-            rtsp_media_source_->set_session(nullptr);
-            auto publish_app = rtsp_media_source_->get_app();
-            start_delayed_source_check_and_delete(publish_app->get_conf()->get_stream_resume_timeout(), rtsp_media_source_);
-            co_await publish_app->on_unpublish(std::static_pointer_cast<StreamSession>(shared_from_this()));
-        }
-
-        if (rtsp_media_sink_) {
-            auto source = rtsp_media_sink_->get_source();
-            if (source) {
-                source->remove_media_sink(rtsp_media_sink_);
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            CORE_DEBUG("closing rtsp sever session:{}", get_session_name());
+            boost::system::error_code ec;
+            if (sock_) {
+                sock_->close();
             }
 
-            rtsp_media_sink_->on_close({});
-            rtsp_media_sink_->close();
-            rtsp_media_sink_.reset();
-        }
-        sock_.reset();
-        CORE_DEBUG("close rtsp sever session:{} done", get_session_name());
-        co_return;
-    }, boost::asio::detached);
+            send_funcs_channel_.close();
+            co_await wg_.wait();
+
+            if (rtsp_media_source_) {
+                rtsp_media_source_->set_session(nullptr);
+                auto publish_app = rtsp_media_source_->get_app();
+                start_delayed_source_check_and_delete(publish_app->get_conf()->get_stream_resume_timeout(),
+                                                      rtsp_media_source_);
+                co_await publish_app->on_unpublish(
+                    std::static_pointer_cast<StreamSession>(shared_from_this()));
+            }
+
+            if (rtsp_media_sink_) {
+                auto source = rtsp_media_sink_->get_source();
+                if (source) {
+                    source->remove_media_sink(rtsp_media_sink_);
+                }
+
+                rtsp_media_sink_->on_close({});
+                rtsp_media_sink_->close();
+                rtsp_media_sink_.reset();
+            }
+            sock_.reset();
+            CORE_DEBUG("close rtsp sever session:{} done", get_session_name());
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 boost::asio::awaitable<bool> RtspServerSession::on_rtsp_request(std::shared_ptr<RtspRequest> req) {
     boost::system::error_code ec;
-    const std::string & method = req->get_method();
+    const std::string &method = req->get_method();
     if (method == RTSP_METHOD_OPTIONS) {
         co_return co_await process_options_req(req);
     } else if (method == RTSP_METHOD_SETUP) {
@@ -296,7 +310,9 @@ boost::asio::awaitable<bool> RtspServerSession::on_rtsp_request(std::shared_ptr<
     resp->add_header("Connection", "close");
     resp->add_header("Server", "mms");
     resp->set_status(RTSP_STATUS_CODE_NOT_IMPLEMENTED, "Not Implemented");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
@@ -309,19 +325,23 @@ boost::asio::awaitable<bool> RtspServerSession::process_options_req(std::shared_
     boost::system::error_code ec;
     std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
     resp->add_header("CSeq", req->get_header("CSeq"));
-    resp->add_header("Public", "OPTIONS, ANNOUNCE, DESCRIBE, SETUP, TEARDOWN, PLAY, RECORD, REDIRECT");//, GET_PARAMETER, SET_PARAMETER
+    resp->add_header(
+        "Public", "OPTIONS, ANNOUNCE, DESCRIBE, SETUP, TEARDOWN, PLAY, RECORD, REDIRECT");  //, GET_PARAMETER,
+                                                                                            //SET_PARAMETER
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
 boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared_ptr<RtspRequest> req) {
     boost::system::error_code ec;
-    const std::string & uri = req->get_uri();
+    const std::string &uri = req->get_uri();
     std::string_view uri_view = uri;
     std::vector<std::string_view> vs;
-    boost::split(vs, uri_view, boost::is_any_of("/"));//  RTSP://DOMAIN/app/stream
+    boost::split(vs, uri_view, boost::is_any_of("/"));  //  RTSP://DOMAIN/app/stream
     if (vs.size() != 5) {
         co_return false;
     }
@@ -333,7 +353,7 @@ boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared
             auto pos = domain.find(":");
             if (pos != std::string::npos) {
                 domain = domain.substr(0, pos);
-            }   
+            }
         }
     }
 
@@ -355,19 +375,24 @@ boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared
         resp->add_header("Connection", "Close");
         resp->add_header("Server", "mms");
         resp->set_status(RTSP_STATUS_CODE_FORBIDDEN, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
     auto self(std::static_pointer_cast<StreamSession>(shared_from_this()));
     // publish auth check
     auto publish_app = std::static_pointer_cast<PublishApp>(app_);
-    auto media_source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
+    auto media_source =
+        SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
     if (!media_source) {
-        media_source = std::make_shared<RtspMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
+        media_source =
+            std::make_shared<RtspMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
     }
 
     if (media_source->get_media_type() != "rtsp{rtp[es]}") {
-        CORE_ERROR("source:{} is already exist and type is:{}", get_session_name(), media_source->get_media_type());
+        CORE_ERROR("source:{} is already exist and type is:{}", get_session_name(),
+                   media_source->get_media_type());
         co_return true;
     }
 
@@ -382,7 +407,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared
         resp->add_header("Connection", "Close");
         resp->add_header("Server", "mms");
         resp->set_status(RTSP_STATUS_CODE_FORBIDDEN, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
     // parse and check sdp
@@ -393,7 +420,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared
         resp->add_header("Connection", "Close");
         resp->add_header("Server", "mms");
         resp->set_status(RTSP_STATUS_CODE_PARAMETER_NOT_UNDERSTOOD, "Parameter Not Understood");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
 
@@ -402,18 +431,18 @@ boost::asio::awaitable<bool> RtspServerSession::process_announce_req(std::shared
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
     resp->set_status(RTSP_STATUS_CODE_OK, "OK");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
 
-    ret = SourceManager::get_instance().add_source(get_domain_name(), 
-                                                        get_app_name(),
-                                                        get_stream_name(),
-                                                        rtsp_media_source_);
+    ret = SourceManager::get_instance().add_source(get_domain_name(), get_app_name(), get_stream_name(),
+                                                   rtsp_media_source_);
     if (!ret) {
         rtsp_media_source_->close();
         co_return false;
     }
     rtsp_media_source_->set_status(E_SOURCE_STATUS_OK);
-    publish_app->on_create_source(get_domain_name(),get_app_name(), get_stream_name(), rtsp_media_source_);
+    publish_app->on_create_source(get_domain_name(), get_app_name(), get_stream_name(), rtsp_media_source_);
     co_return true;
 }
 
@@ -424,10 +453,10 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
 
-    const std::string & uri = req->get_uri();
+    const std::string &uri = req->get_uri();
     std::string_view uri_view = uri;
     std::vector<std::string_view> vs;
-    boost::split(vs, uri_view, boost::is_any_of("/"));//  RTSP://domain/app/stream
+    boost::split(vs, uri_view, boost::is_any_of("/"));  //  RTSP://domain/app/stream
     if (vs.size() != 5) {
         co_return false;
     }
@@ -439,7 +468,7 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
             auto pos = domain.find(":");
             if (pos != std::string::npos) {
                 domain = domain.substr(0, pos);
-            }   
+            }
         }
     }
 
@@ -457,7 +486,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
         CORE_ERROR("could not find conf for session:{}", get_session_name());
         resp->add_header("Connection", "close");
         resp->set_status(403, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return false;
     }
 
@@ -468,7 +499,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
         CORE_ERROR("play auth check failed, reason:{}", err.msg);
         resp->add_header("Connection", "Close");
         resp->set_status(403, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return false;
     }
 
@@ -476,14 +509,17 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
     if (!publish_app) {
         resp->add_header("Connection", "Close");
         resp->set_status(403, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return false;
     }
-    
+
     auto source_name = publish_app->get_domain_name() + "/" + app_name_ + "/" + stream_name_;
     // todo: how to record 404 error to log.
-    auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
-    if (!source) {// 2.本地配置查找外部回源
+    auto source =
+        SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
+    if (!source) {  // 2.本地配置查找外部回源
         source = co_await publish_app->find_media_source(self);
     }
 
@@ -492,19 +528,22 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
     //     source = co_await MediaCenterManager::get_instance().find_and_create_pull_media_source(self);
     // }
 
-    if (!source) {//todo:发送STREAM NOT FOUND
+    if (!source) {  // todo:发送STREAM NOT FOUND
         resp->add_header("Connection", "close");
         resp->set_status(404, "Not Found");
         CORE_DEBUG("could not find source:{}", source_name);
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return false;
     }
 
     // 4. 判断是否需要进行桥转换
     std::shared_ptr<MediaBridge> bridge;
     if (source->get_media_type() != "rtsp{rtp[es]}") {
-        bridge = source->get_or_create_bridge(source->get_media_type() + "-rtsp{rtp[es]}", publish_app, stream_name_);
-        if (!bridge) {// todo:发送FORBIDDEN
+        bridge = source->get_or_create_bridge(source->get_media_type() + "-rtsp{rtp[es]}", publish_app,
+                                              stream_name_);
+        if (!bridge) {  // todo:发送FORBIDDEN
             spdlog::error("could not create bridge:{}", source->get_media_type() + "-rtsp{rtp[es]}");
             co_return false;
         }
@@ -513,17 +552,17 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
 
     play_source_ = std::dynamic_pointer_cast<RtspMediaSource>(source);
     // 5. 真的没找到
-    if (!play_source_) {//todo : reply 404
+    if (!play_source_) {  // todo : reply 404
         resp->add_header("Connection", "close");
         resp->set_status(404, "Not Found");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
-    } 
+    }
 
     rtsp_media_sink_ = std::make_shared<RtspMediaSink>(get_worker());
-    rtsp_media_sink_->on_close([this, self]() {
-        close();
-    });
+    rtsp_media_sink_->on_close([this, self]() { close(); });
 
     int32_t try_get_play_sdp_count = 0;
     std::shared_ptr<Sdp> source_sdp;
@@ -539,8 +578,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
         }
 
         boost::system::error_code ec;
-        play_sdp_timeout_timer_.expires_from_now(std::chrono::milliseconds(10));
-        co_await play_sdp_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        play_sdp_timeout_timer_.expires_after(std::chrono::milliseconds(10));
+        co_await play_sdp_timeout_timer_.async_wait(
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         if (ec) {
             break;
         }
@@ -549,21 +589,21 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
     if (!source_sdp) {
         resp->add_header("Connection", "close");
         resp->set_status(504, "Gateway timeout");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
 
-    auto & source_medias = source_sdp->get_media_sdps();
-    auto & describe_sdp = rtsp_media_sink_->get_describe_sdp();
+    auto &source_medias = source_sdp->get_media_sdps();
+    auto &describe_sdp = rtsp_media_sink_->get_describe_sdp();
     describe_sdp.set_version(0);
-    describe_sdp.set_origin(source_sdp->get_origin()); // o=- get_rand64 1 IN IP4 127.0.0.1
-    describe_sdp.set_session_name(session_name_);                                  //
-    describe_sdp.set_time({0, 0});                                                // t=0 0
+    describe_sdp.set_origin(source_sdp->get_origin());  // o=- get_rand64 1 IN IP4 127.0.0.1
+    describe_sdp.set_session_name(session_name_);       //
+    describe_sdp.set_time({0, 0});                      // t=0 0
     describe_sdp.set_tool({"mms"});
-    for (auto &media : source_medias)
-    {
-        if (media.get_media() == "audio")
-        {
+    for (auto &media : source_medias) {
+        if (media.get_media() == "audio") {
             MediaSdp audio_sdp;
             audio_sdp.set_media("audio");
             audio_sdp.set_port(0);
@@ -572,17 +612,17 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
             audio_sdp.set_control(media.get_control().value());
             audio_sdp.add_fmt(play_source_->get_audio_pt());
 
-            auto & payloads = media.get_payloads();
+            auto &payloads = media.get_payloads();
             auto it_payload = payloads.begin();
-            
+
             rtsp_media_sink_->set_audio_pt(it_payload->first);
-            Payload audio_payload(it_payload->first, it_payload->second.get_encoding_name(), it_payload->second.get_clock_rate(), it_payload->second.get_encoding_params());
+            Payload audio_payload(it_payload->first, it_payload->second.get_encoding_name(),
+                                  it_payload->second.get_clock_rate(),
+                                  it_payload->second.get_encoding_params());
             audio_payload.set_fmtps(it_payload->second.get_fmtps());
             audio_sdp.add_payload(audio_payload);
             describe_sdp.add_media_sdp(audio_sdp);
-        }
-        else if (media.get_media() == "video")
-        {
+        } else if (media.get_media() == "video") {
             MediaSdp video_sdp;
             video_sdp.set_media("video");
             video_sdp.set_port(0);
@@ -590,11 +630,13 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
             video_sdp.set_proto(media.get_proto());
             video_sdp.add_fmt(play_source_->get_video_pt());
             video_sdp.set_control(media.get_control().value());
-            auto & payloads = media.get_payloads();
+            auto &payloads = media.get_payloads();
             auto it_payload = payloads.begin();
 
             rtsp_media_sink_->set_video_pt(it_payload->first);
-            Payload video_payload(it_payload->first, it_payload->second.get_encoding_name(), it_payload->second.get_clock_rate(), it_payload->second.get_encoding_params());
+            Payload video_payload(it_payload->first, it_payload->second.get_encoding_name(),
+                                  it_payload->second.get_clock_rate(),
+                                  it_payload->second.get_encoding_params());
             video_payload.set_fmtps(it_payload->second.get_fmtps());
             video_sdp.add_payload(video_payload);
             describe_sdp.add_media_sdp(video_sdp);
@@ -607,14 +649,16 @@ boost::asio::awaitable<bool> RtspServerSession::process_describe_req(std::shared
     resp->add_header("Content-Type", "application/sdp");
     resp->add_header("Content-Length", std::to_string(response_sdp.size()));
     resp->set_body(response_sdp);
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
 boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_ptr<RtspRequest> req) {
     boost::system::error_code ec;
     std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
-    const std::string & uri = req->get_uri();
+    const std::string &uri = req->get_uri();
     std::vector<std::string_view> vs_url;
     boost::split(vs_url, uri, boost::is_any_of("/"));
     if (vs_url.size() != 6) {
@@ -622,23 +666,26 @@ boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_pt
         resp->add_header("Connection", "Close");
         resp->add_header("Server", "mms");
         resp->set_status(RTSP_STATUS_CODE_FORBIDDEN, "Forbidden");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
 
-    const std::string_view & control = vs_url[5];
+    const std::string_view &control = vs_url[5];
     if (rtsp_media_source_) {
         auto sdp = rtsp_media_source_->get_announce_sdp();
         const auto &remote_medias = sdp->get_media_sdps();
-        for (const auto &media : remote_medias)
-        {
-            auto & ctrl = media.get_control();
+        for (const auto &media : remote_medias) {
+            auto &ctrl = media.get_control();
             if (!ctrl) {
                 resp->add_header("CSeq", req->get_header("CSeq"));
                 resp->add_header("Connection", "Close");
                 resp->add_header("Server", "mms");
                 resp->set_status(RTSP_STATUS_CODE_PARAMETER_NOT_UNDERSTOOD, "Parameter Not Understood");
-                co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                co_await send_funcs_channel_.async_send(
+                    boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
                 co_return true;
             }
 
@@ -647,10 +694,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_pt
             }
         }
     } else if (rtsp_media_sink_) {
-
     }
 
-    const std::string & transport = req->get_header("Transport");
+    const std::string &transport = req->get_header("Transport");
     std::string_view tview = transport;
     std::vector<std::string_view> vs;
     boost::split(vs, tview, boost::is_any_of(";"));
@@ -659,12 +705,14 @@ boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_pt
         resp->add_header("Connection", "Close");
         resp->add_header("Server", "mms");
         resp->set_status(RTSP_STATUS_CODE_PARAMETER_NOT_UNDERSTOOD, "Parameter Not Understood");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
     }
 
     if (vs[0] == "RTP/AVP/TCP") {
-        is_tcp_transport_  = true;
+        is_tcp_transport_ = true;
     } else if (vs[0] == "RTP/AVP/UDP") {
         is_udp_transport_ = true;
     }
@@ -674,7 +722,7 @@ boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_pt
     } else if (vs[1] == "multicast") {
         is_multicast_ = true;
     }
-    
+
     resp->add_header("CSeq", req->get_header("CSeq"));
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
@@ -688,9 +736,11 @@ boost::asio::awaitable<bool> RtspServerSession::process_setup_req(std::shared_pt
             resp->add_header("Transport", "RTP/AVP/TCP;unicast;interleaved=2-3;mode=\"PLAY\"");
         }
     }
-    
+
     resp->set_status(RTSP_STATUS_CODE_OK, "OK");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
@@ -701,7 +751,9 @@ boost::asio::awaitable<bool> RtspServerSession::process_record_req(std::shared_p
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
     resp->set_status(RTSP_STATUS_CODE_OK, "OK");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
@@ -711,38 +763,51 @@ boost::asio::awaitable<bool> RtspServerSession::process_play_req(std::shared_ptr
     std::shared_ptr<RtspResponse> resp = std::make_shared<RtspResponse>();
     // todo: how to record 404 error to log.
     auto app = get_app();
-    if (!play_source_) {//todo : reply 404
+    if (!play_source_) {  // todo : reply 404
         resp->add_header("Connection", "close");
         resp->set_status(404, "Not Found");
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                                std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         co_return true;
-    } 
+    }
 
-    rtsp_media_sink_->set_video_pkts_cb([this](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        boost::system::error_code ec;
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtp_over_tcp_pkts, this, pkts), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-        if (ec) {
-            co_return false;
-        }
-        co_return true;
-    });
+    rtsp_media_sink_->set_video_pkts_cb(
+        [this](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            boost::system::error_code ec;
+            co_await send_funcs_channel_.async_send(
+                boost::system::error_code{},
+                std::bind(&RtspServerSession::send_rtp_over_tcp_pkts, this, pkts),
+                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return false;
+            }
+            co_return true;
+        });
 
-    rtsp_media_sink_->set_audio_pkts_cb([this](std::vector<std::shared_ptr<RtpPacket>> pkts)->boost::asio::awaitable<bool> {
-        boost::system::error_code ec;
-        co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtp_over_tcp_pkts, this, pkts), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-        if (ec) {
-            co_return false;
-        }
-        co_return true;
-    });
+    rtsp_media_sink_->set_audio_pkts_cb(
+        [this](std::vector<std::shared_ptr<RtpPacket>> pkts) -> boost::asio::awaitable<bool> {
+            boost::system::error_code ec;
+            co_await send_funcs_channel_.async_send(
+                boost::system::error_code{},
+                std::bind(&RtspServerSession::send_rtp_over_tcp_pkts, this, pkts),
+                boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
+                co_return false;
+            }
+            co_return true;
+        });
 
     play_source_->add_media_sink(rtsp_media_sink_);
     resp->add_header("CSeq", req->get_header("CSeq"));
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
-    resp->add_header("RTP-Info", "url=rtsp://" + session_name_ + "/streamid=0,url=rtsp://" + session_name_ + "/streamid=1");
+    resp->add_header("RTP-Info", "url=rtsp://" + session_name_ + "/streamid=0,url=rtsp://" + session_name_ +
+                                     "/streamid=1");
     resp->set_status(RTSP_STATUS_CODE_OK, "OK");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }
 
@@ -753,6 +818,8 @@ boost::asio::awaitable<bool> RtspServerSession::process_teardown_req(std::shared
     resp->add_header("Server", "mms");
     resp->add_header("Session", std::to_string(session_id_) + ";timeout=60");
     resp->set_status(RTSP_STATUS_CODE_OK, "OK");
-    co_await send_funcs_channel_.async_send(boost::system::error_code{}, std::bind(&RtspServerSession::send_rtsp_resp, this, resp), boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+    co_await send_funcs_channel_.async_send(boost::system::error_code{},
+                                            std::bind(&RtspServerSession::send_rtsp_resp, this, resp),
+                                            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     co_return true;
 }

--- a/live-server/server/stun/protocol/stun_binding_response_msg.hpp
+++ b/live-server/server/stun/protocol/stun_binding_response_msg.hpp
@@ -2,12 +2,14 @@
 #include <memory>
 
 #include "stun_define.hpp"
+#include "stun_msg.h"
+
 namespace mms {
 struct StunBindingResponseMsg : public StunMsg {
 public:
-    StunBindingResponseMsg(StunMsg & stun_msg) {
+    StunBindingResponseMsg(StunMsg& stun_msg) {
         header.type = STUN_BINDING_RESPONSE;
         memcpy(header.transaction_id, stun_msg.header.transaction_id, 16);
     }
 };
-};
+};  // namespace mms

--- a/live-server/server/webrtc/dtls/boringssl_session.cpp
+++ b/live-server/server/webrtc/dtls/boringssl_session.cpp
@@ -3,71 +3,66 @@
  * @Date: 2023-08-26 22:56:09
  * @LastEditTime: 2023-12-03 11:15:45
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\server\webrtc\dtls_boringssl\dtls_boringssl_session.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
-#include <variant>
 #include <boost/asio/experimental/awaitable_operators.hpp>
+#include <variant>
+
 using namespace boost::asio::experimental::awaitable_operators;
 
-#include "boringssl_session.h"
-#include "base/utils/utils.h"
-#include "config/config.h"
-#include "spdlog/spdlog.h"
-#include "dtls_cert.h"
-#include "base/thread/thread_worker.hpp"
 #include "../webrtc_server_session.hpp"
+#include "base/thread/thread_worker.hpp"
+#include "base/utils/utils.h"
+#include "boringssl_session.h"
+#include "config/config.h"
+#include "dtls_cert.h"
+#include "spdlog/spdlog.h"
+
 
 using namespace mms;
 #define TLS_MAX_RECV_BUF 1024 * 1024
 
-DtlsBoringSSLSession::DtlsBoringSSLSession(ThreadWorker *worker, WebRtcServerSession & session) : worker_(worker), 
-                                                                                            timeout_timer_(worker->get_io_context()), 
-                                                                                            session_(session), 
-                                                                                            dtls_state_channel_(worker->get_io_context()), 
-                                                                                            handshaking_coroutine_exited_(worker->get_io_context())
-{
+DtlsBoringSSLSession::DtlsBoringSSLSession(ThreadWorker *worker, WebRtcServerSession &session)
+    : worker_(worker),
+      timeout_timer_(worker->get_io_context()),
+      session_(session),
+      dtls_state_channel_(worker->get_io_context()),
+      handshaking_coroutine_exited_(worker->get_io_context()) {
     encrypted_buf_ = new uint8_t[TLS_MAX_RECV_BUF];
 }
 
-DtlsBoringSSLSession::~DtlsBoringSSLSession()
-{
+DtlsBoringSSLSession::~DtlsBoringSSLSession() {
     spdlog::debug("destroy DtlsBoringSSLSession");
-    if (ssl_)
-    {
+    if (ssl_) {
         SSL_free(ssl_);
         ssl_ = nullptr;
     }
 
     // bio_read_,bio_write_ 已经绑定了ssl_，所以不需要额外释放，否则内存异常
-    if (ssl_ctx_)
-    {
+    if (ssl_ctx_) {
         SSL_CTX_free(ssl_ctx_);
         ssl_ctx_ = nullptr;
     }
 
-    if (encrypted_buf_)
-    {
+    if (encrypted_buf_) {
         delete[] encrypted_buf_;
         encrypted_buf_ = nullptr;
     }
 }
 
-int DtlsBoringSSLSession::on_ssl_certificate_verify(int /*preverifyOk*/, X509_STORE_CTX * /*ctx*/)
-{
+int DtlsBoringSSLSession::on_ssl_certificate_verify(int /*preverifyOk*/, X509_STORE_CTX * /*ctx*/) {
     // Always valid since DTLS certificates are self-signed.
     return 1;
 }
 
-void DtlsBoringSSLSession::on_ssl_info(const SSL *ssl, int where, int ret)
-{
+void DtlsBoringSSLSession::on_ssl_info(const SSL *ssl, int where, int ret) {
     DtlsBoringSSLSession *this_ptr = (DtlsBoringSSLSession *)SSL_get_ex_data(ssl, 0);
     this_ptr->do_on_ssl_info(ssl, where, ret);
 }
 
-void DtlsBoringSSLSession::do_on_ssl_info(const SSL *ssl, int where, int ret)
-{
+void DtlsBoringSSLSession::do_on_ssl_info(const SSL *ssl, int where, int ret) {
     (void)ssl;
     int w = where & -SSL_ST_MASK;
     const char *role;
@@ -79,78 +74,63 @@ void DtlsBoringSSLSession::do_on_ssl_info(const SSL *ssl, int where, int ret)
     else
         role = "undefined";
 
-    if ((where & SSL_CB_LOOP) != 0)
-    {
+    if ((where & SSL_CB_LOOP) != 0) {
         spdlog::debug("[role:{}, action:{}]", role, SSL_state_string_long(ssl_));
-    }
-    else if ((where & SSL_CB_ALERT) != 0)
-    {
+    } else if ((where & SSL_CB_ALERT) != 0) {
         const char *alertType;
 
-        switch (*SSL_alert_type_string(ret))
-        {
-        case 'W':
-            alertType = "warning";
-            break;
+        switch (*SSL_alert_type_string(ret)) {
+            case 'W':
+                alertType = "warning";
+                break;
 
-        case 'F':
-            alertType = "fatal";
-            break;
+            case 'F':
+                alertType = "fatal";
+                break;
 
-        default:
-            alertType = "undefined";
+            default:
+                alertType = "undefined";
         }
 
-        if ((where & SSL_CB_READ) != 0)
-        {
+        if ((where & SSL_CB_READ) != 0) {
             spdlog::warn("received DTLS {} alert: {}", alertType, SSL_alert_desc_string_long(ret));
-            if ((ret&0xff) == SSL3_AD_CLOSE_NOTIFY) {
-
+            if ((ret & 0xff) == SSL3_AD_CLOSE_NOTIFY) {
             }
-        }
-        else if ((where & SSL_CB_WRITE) != 0)
-        {
+        } else if ((where & SSL_CB_WRITE) != 0) {
             spdlog::warn("sending DTLS {} alert: {}", alertType, SSL_alert_desc_string_long(ret));
-        }
-        else
-        {
+        } else {
             spdlog::debug("DTLS {} alert: {}", alertType, SSL_alert_desc_string_long(ret));
         }
-    }
-    else if ((where & SSL_CB_EXIT) != 0)
-    {
+    } else if ((where & SSL_CB_EXIT) != 0) {
         if (ret == 0)
             spdlog::debug("[role:{}, failed:'{}']", role, SSL_state_string_long(ssl_));
         else if (ret < 0)
             spdlog::debug("role: {}, waiting:'{}']", role, SSL_state_string_long(ssl_));
-    }
-    else if ((where & SSL_CB_HANDSHAKE_START) != 0)
-    {
+    } else if ((where & SSL_CB_HANDSHAKE_START) != 0) {
         spdlog::debug("DTLS handshake start");
-    }
-    else if ((where & SSL_CB_HANDSHAKE_DONE) != 0)
-    {
+    } else if ((where & SSL_CB_HANDSHAKE_DONE) != 0) {
         spdlog::debug("DTLS handshake done");
         uint8_t material[SRTP_MASTER_KEY_LEN * 2] = {0};
         static const std::string dtls_label = "EXTRACTOR-dtls_srtp";
-        auto ret = SSL_export_keying_material(ssl_, material, sizeof(material), dtls_label.c_str(), dtls_label.size(), NULL, 0, 0);
+        auto ret = SSL_export_keying_material(ssl_, material, sizeof(material), dtls_label.c_str(),
+                                              dtls_label.size(), NULL, 0, 0);
         if (ret <= 0) {
             dtls_state_channel_.close();
             timeout_timer_.cancel();
             return;
         }
         handshake_done_ = true;
-        int srtp_key_len  = 16;
+        int srtp_key_len = 16;
         int srtp_salt_len = 14;
 
         size_t offset = 0;
-        std::string client_master_key((char*)(material), srtp_key_len);
+        std::string client_master_key((char *)(material), srtp_key_len);
         offset += srtp_key_len;
-        std::string server_master_key((char*)(material + offset), srtp_key_len);
+        std::string server_master_key((char *)(material + offset), srtp_key_len);
         offset += srtp_key_len;
-        std::string client_master_salt((char*)(material + offset), srtp_salt_len);
+        std::string client_master_salt((char *)(material + offset), srtp_salt_len);
         offset += srtp_salt_len;
-        std::string server_master_salt((char*)(material + offset), srtp_salt_len);
+        std::string server_master_salt((char *)(material + offset), srtp_salt_len);
 
         srtp_recv_key_ = client_master_key + client_master_salt;
         srtp_send_key_ = server_master_key + server_master_salt;
@@ -161,17 +141,18 @@ void DtlsBoringSSLSession::do_on_ssl_info(const SSL *ssl, int where, int ret)
     }
 }
 
-unsigned int DtlsBoringSSLSession::on_ssl_dtls_timer(SSL* ssl, unsigned int timer_us) {
+unsigned int DtlsBoringSSLSession::on_ssl_dtls_timer(SSL *ssl, unsigned int timer_us) {
     (void)ssl;
     if (timer_us == 0)
-		return 100000;
-	else if (timer_us >= 4000000)
-		return 4000000;
-	else
-		return 2 * timer_us;
+        return 100000;
+    else if (timer_us >= 4000000)
+        return 4000000;
+    else
+        return 2 * timer_us;
 }
 
-boost::asio::awaitable<int32_t> DtlsBoringSSLSession::do_handshake(mode m, std::shared_ptr<DtlsCert> dtls_cert) {
+boost::asio::awaitable<int32_t> DtlsBoringSSLSession::do_handshake(mode m,
+                                                                   std::shared_ptr<DtlsCert> dtls_cert) {
     (void)m;
     dtls_cert_ = dtls_cert;
     ssl_ctx_ = SSL_CTX_new(DTLS_method());
@@ -184,32 +165,35 @@ boost::asio::awaitable<int32_t> DtlsBoringSSLSession::do_handshake(mode m, std::
 
     auto conf = Config::get_instance();
 
-    if (!SSL_CTX_use_PrivateKey(ssl_ctx_, dtls_cert_->get_pkey()))
-    {
-        spdlog::error("load dtls key file:{} failed.", Utils::get_bin_path() + conf->get_cert_root() + "/server.crt");
+    if (!SSL_CTX_use_PrivateKey(ssl_ctx_, dtls_cert_->get_pkey())) {
+        spdlog::error("load dtls key file:{} failed.",
+                      Utils::get_bin_path() + conf->get_cert_root() + "/server.crt");
         co_return -4;
     }
 
-    if (!SSL_CTX_use_certificate(ssl_ctx_, dtls_cert_->get_cert()))
-    {
-        spdlog::error("load dtls cert file:{} failed.", (Utils::get_bin_path() + conf->get_cert_root() + "/server.key"));
+    if (!SSL_CTX_use_certificate(ssl_ctx_, dtls_cert_->get_cert())) {
+        spdlog::error("load dtls cert file:{} failed.",
+                      (Utils::get_bin_path() + conf->get_cert_root() + "/server.key"));
         co_return -5;
     }
 
     SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_NONE, NULL);
-    SSL_CTX_set_options(ssl_ctx_, SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_TICKET | SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_QUERY_MTU);
+    SSL_CTX_set_options(ssl_ctx_, SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_NO_TICKET |
+                                      SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_QUERY_MTU);
     SSL_CTX_set_session_cache_mode(ssl_ctx_, SSL_SESS_CACHE_OFF);
     SSL_CTX_set_read_ahead(ssl_ctx_, 1);
     SSL_CTX_set_verify_depth(ssl_ctx_, 4);
-    SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, on_ssl_certificate_verify);
+    SSL_CTX_set_verify(ssl_ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                       on_ssl_certificate_verify);
     SSL_CTX_set_info_callback(ssl_ctx_, on_ssl_info);
-    auto ret = SSL_CTX_set_cipher_list(ssl_ctx_, "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK");
+    auto ret =
+        SSL_CTX_set_cipher_list(ssl_ctx_, "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK");
     if (!ret) {
         co_return -6;
     }
 
     // For OpenSSL >= 1.0.2.
-	// SSL_CTX_set_ecdh_auto(ssl_ctx_, 1);
+    // SSL_CTX_set_ecdh_auto(ssl_ctx_, 1);
     ret = SSL_CTX_set_tlsext_use_srtp(ssl_ctx_, "SRTP_AES128_CM_SHA1_80");
     if (0 != ret) {
         co_return -7;
@@ -246,59 +230,68 @@ boost::asio::awaitable<int32_t> DtlsBoringSSLSession::do_handshake(mode m, std::
     // 启动定时器
     auto self(shared_from_this());
     handshake_coroutine_running_ = true;
-    boost::asio::co_spawn(worker_->get_io_context(), [this]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            struct timeval dtls_timeout;
-            int r = DTLSv1_get_timeout(ssl_, &dtls_timeout); // NOLINT
-            if (r != 1) {
-                timeout_timer_.expires_from_now(std::chrono::milliseconds(5));
-                co_await timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-                if (ec) {
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                struct timeval dtls_timeout;
+                int r = DTLSv1_get_timeout(ssl_, &dtls_timeout);  // NOLINT
+                if (r != 1) {
+                    timeout_timer_.expires_after(std::chrono::milliseconds(5));
+                    co_await timeout_timer_.async_wait(
+                        boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                    if (ec) {
+                        break;
+                    }
+                    continue;
+                }
+
+                uint64_t timeout_ms = 0;
+                timeout_ms =
+                    (dtls_timeout.tv_sec * static_cast<uint64_t>(1000)) + (dtls_timeout.tv_usec / 1000);
+                if (timeout_ms >= 30000) {
+                    co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED,
+                                                            boost::asio::use_awaitable);
                     break;
                 }
-                continue;
-            }
 
-            uint64_t timeout_ms = 0;
-            timeout_ms = (dtls_timeout.tv_sec * static_cast<uint64_t>(1000)) + (dtls_timeout.tv_usec / 1000);
-            if (timeout_ms >= 30000) {
-                co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED, boost::asio::use_awaitable);
-                break;
-            }
-            
-            co_await timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED, boost::asio::use_awaitable);
-                break;
-            }
+                co_await timeout_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED,
+                                                            boost::asio::use_awaitable);
+                    break;
+                }
 
-            // 超时
-            // DTLSv1_handle_timeout is called when a DTLS handshake timeout expires.
-            // If no timeout had expired, it returns 0. Otherwise, it retransmits the
-            // previous flight of handshake messages and returns 1. If too many timeouts
-            // had expired without progress or an error occurs, it returns -1.
-            auto ret = DTLSv1_handle_timeout(ssl_);
-            if (ret == 1) {
-                co_await send_pending_outgoing_dtls_packet();
-            } else if (ret == -1) {
-                co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED, boost::asio::use_awaitable);
-                break;
+                // 超时
+                // DTLSv1_handle_timeout is called when a DTLS handshake timeout expires.
+                // If no timeout had expired, it returns 0. Otherwise, it retransmits the
+                // previous flight of handshake messages and returns 1. If too many timeouts
+                // had expired without progress or an error occurs, it returns -1.
+                auto ret = DTLSv1_handle_timeout(ssl_);
+                if (ret == 1) {
+                    co_await send_pending_outgoing_dtls_packet();
+                } else if (ret == -1) {
+                    co_await dtls_state_channel_.async_send(boost::system::error_code{}, FAILED,
+                                                            boost::asio::use_awaitable);
+                    break;
+                }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        handshake_coroutine_running_ = false;
-        handshaking_coroutine_exited_.close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            handshake_coroutine_running_ = false;
+            handshaking_coroutine_exited_.close();
+        });
 
     boost::system::error_code ec;
     co_await dtls_state_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     timeout_timer_.cancel();
     // 设置超时回调
-    // This function sets an optional callback function for controlling the timeout interval on the DTLS protocol. 
-    // The callback function will be called by DTLS for every new DTLS packet that is sent.
+    // This function sets an optional callback function for controlling the timeout interval on the DTLS
+    // protocol. The callback function will be called by DTLS for every new DTLS packet that is sent.
     // DTLS_set_timer_cb(ssl_, on_ssl_dtls_timer);
     if (!handshake_done_) {
         co_return -11;
@@ -317,55 +310,56 @@ boost::asio::awaitable<void> DtlsBoringSSLSession::close() {
         if (dtls_state_channel_.is_open()) {
             dtls_state_channel_.close();
         }
-        co_await handshaking_coroutine_exited_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        co_await handshaking_coroutine_exited_.async_receive(
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
     }
     co_return;
 }
 
-boost::asio::awaitable<bool> DtlsBoringSSLSession::process_dtls_packet(uint8_t *data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep)
-{
+boost::asio::awaitable<bool> DtlsBoringSSLSession::process_dtls_packet(
+    uint8_t *data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep) {
     (void)sock;
     (void)remote_ep;
     int written = BIO_write(bio_read_, data, len);
-    if (written <= 0) {   
+    if (written <= 0) {
         co_return false;
     }
     SSL_do_handshake(ssl_);
 
-    auto read = SSL_read(ssl_, encrypted_buf_, 1024*1024);
+    auto read = SSL_read(ssl_, encrypted_buf_, 1024 * 1024);
     if (read <= 0) {
         int err = SSL_get_error(ssl_, read);
         switch (err) {
-        case SSL_ERROR_NONE:
-            spdlog::debug("SSL_ERROR_NONE");
-            break;
-        case SSL_ERROR_SSL:
-            spdlog::debug("SSL_ERROR_SSL");
-            break;
-        case SSL_ERROR_WANT_READ:
-            spdlog::debug("SSL_ERROR_WANT_READ");
-            break;
-        case SSL_ERROR_WANT_WRITE:
-            spdlog::debug("SSL_ERROR_WANT_WRITE");
-            break;
-        case SSL_ERROR_WANT_X509_LOOKUP:
-            spdlog::debug("SSL_ERROR_WANT_X509_LOOKUP");
-            break;
-        case SSL_ERROR_SYSCALL:
-            spdlog::debug("SSL_ERROR_SYSCALL");
-            break;
-        case SSL_ERROR_ZERO_RETURN:
-            spdlog::debug("SSL_ERROR_ZERO_RETURN");
-            break;
-        case SSL_ERROR_WANT_CONNECT:
-            spdlog::debug("SSL_ERROR_WANT_CONNECT");
-            break;
-        case SSL_ERROR_WANT_ACCEPT:
-            spdlog::debug("SSL_ERROR_WANT_ACCEPT");
-            break;
-        default:
-            spdlog::debug("SSL_ERROR_UNKNOWN");
-            break;
+            case SSL_ERROR_NONE:
+                spdlog::debug("SSL_ERROR_NONE");
+                break;
+            case SSL_ERROR_SSL:
+                spdlog::debug("SSL_ERROR_SSL");
+                break;
+            case SSL_ERROR_WANT_READ:
+                spdlog::debug("SSL_ERROR_WANT_READ");
+                break;
+            case SSL_ERROR_WANT_WRITE:
+                spdlog::debug("SSL_ERROR_WANT_WRITE");
+                break;
+            case SSL_ERROR_WANT_X509_LOOKUP:
+                spdlog::debug("SSL_ERROR_WANT_X509_LOOKUP");
+                break;
+            case SSL_ERROR_SYSCALL:
+                spdlog::debug("SSL_ERROR_SYSCALL");
+                break;
+            case SSL_ERROR_ZERO_RETURN:
+                spdlog::debug("SSL_ERROR_ZERO_RETURN");
+                break;
+            case SSL_ERROR_WANT_CONNECT:
+                spdlog::debug("SSL_ERROR_WANT_CONNECT");
+                break;
+            case SSL_ERROR_WANT_ACCEPT:
+                spdlog::debug("SSL_ERROR_WANT_ACCEPT");
+                break;
+            default:
+                spdlog::debug("SSL_ERROR_UNKNOWN");
+                break;
         }
     }
     co_await send_pending_outgoing_dtls_packet();
@@ -378,12 +372,12 @@ boost::asio::awaitable<void> DtlsBoringSSLSession::send_pending_outgoing_dtls_pa
     }
 
     int64_t read;
-    char* data = nullptr;
-    read = BIO_get_mem_data(bio_write_, &data); // NOLINT
+    char *data = nullptr;
+    read = BIO_get_mem_data(bio_write_, &data);  // NOLINT
     if (read <= 0) {
         co_return;
     }
-    co_await session_.send_udp_msg((uint8_t*)data, read);
+    co_await session_.send_udp_msg((uint8_t *)data, read);
     // 发送出去
     BIO_reset(bio_write_);
     co_return;

--- a/live-server/server/webrtc/webrtc_server.hpp
+++ b/live-server/server/webrtc/webrtc_server.hpp
@@ -1,10 +1,12 @@
 #pragma once
-#include <unordered_map>
-#include <memory>
 #include <iostream>
+#include <map>
+#include <memory>
+#include <unordered_map>
 
 #include "server/udp/udp_server.hpp"
 #include "srtp/srtp_session.h"
+
 
 namespace mms {
 class WebSocketConn;
@@ -17,7 +19,7 @@ class HttpRequest;
 class HttpResponse;
 
 struct hash_endpoint {
-    size_t operator()(const boost::asio::ip::udp::endpoint& p) const {
+    size_t operator()(const boost::asio::ip::udp::endpoint &p) const {
         return std::hash<std::string>()(p.address().to_string()) ^ std::hash<int>()(p.port());
     }
 };
@@ -29,43 +31,51 @@ public:
 
 class WebRtcServer : public UdpServer, public WebRtcServerSessionCloseHandler {
 public:
-    WebRtcServer(const std::vector<ThreadWorker*> & workers) : UdpServer(workers), workers_(workers) {
-    }
+    WebRtcServer(const std::vector<ThreadWorker *> &workers) : UdpServer(workers), workers_(workers) {}
 
-    virtual ~WebRtcServer()
-    {
-        srtp_shutdown();
-    }
+    virtual ~WebRtcServer() { srtp_shutdown(); }
 
-    bool start(const std::string & listen_ip, const std::string & extern_ip, uint16_t port);
+    bool start(const std::string &listen_ip, const std::string &extern_ip, uint16_t port);
     void stop();
 
-    boost::asio::awaitable<void> on_whip(std::shared_ptr<HttpRequest> req, std::shared_ptr<HttpResponse> resp);
-    boost::asio::awaitable<void> on_whep(std::shared_ptr<HttpRequest> req, std::shared_ptr<HttpResponse> resp);
+    boost::asio::awaitable<void> on_whip(std::shared_ptr<HttpRequest> req,
+                                         std::shared_ptr<HttpResponse> resp);
+    boost::asio::awaitable<void> on_whep(std::shared_ptr<HttpRequest> req,
+                                         std::shared_ptr<HttpResponse> resp);
     static std::shared_ptr<DtlsCert> get_default_dtls_cert();
+
 private:
-    boost::asio::awaitable<void> on_udp_socket_recv(UdpSocket *sock, std::unique_ptr<uint8_t[]> data, size_t len, boost::asio::ip::udp::endpoint &remote_ep) override;
-    boost::asio::awaitable<bool> process_stun_packet(std::shared_ptr<StunMsg> stun_msg, std::unique_ptr<uint8_t[]> data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep);
+    boost::asio::awaitable<void> on_udp_socket_recv(UdpSocket *sock, std::unique_ptr<uint8_t[]> data,
+                                                    size_t len,
+                                                    boost::asio::ip::udp::endpoint &remote_ep) override;
+    boost::asio::awaitable<bool> process_stun_packet(std::shared_ptr<StunMsg> stun_msg,
+                                                     std::unique_ptr<uint8_t[]> data, size_t len,
+                                                     UdpSocket *sock,
+                                                     const boost::asio::ip::udp::endpoint &remote_ep);
+
 private:
     void on_webrtc_session_close(std::shared_ptr<WebRtcServerSession> session);
+
 private:
-    uint64_t get_endpoint_hash(const boost::asio::ip::udp::endpoint& ep);
+    uint64_t get_endpoint_hash(const boost::asio::ip::udp::endpoint &ep);
+
 private:
     bool init_srtp();
     bool init_certs();
+
 private:
     std::string listen_ip_;
     std::string extern_ip_;
     uint16_t listen_udp_port_;
     int32_t using_udp_socket_index_ = 0;
     std::atomic<uint32_t> using_worker_ = 0;
-    std::vector<ThreadWorker*> workers_;
+    std::vector<ThreadWorker *> workers_;
     std::mutex mtx_;
     std::mutex session_map_mtx_;
     std::unordered_map<uint64_t, std::shared_ptr<WebRtcServerSession>> endpoint_session_map_;
-    std::multimap<WebRtcServerSession*, uint64_t> session_endpoint_map_;
+    std::multimap<WebRtcServerSession *, uint64_t> session_endpoint_map_;
     std::unordered_map<std::string, std::shared_ptr<WebRtcServerSession>> ufrag_session_map_;
 
     static std::shared_ptr<DtlsCert> default_dtls_cert_;
 };
-};
+};  // namespace mms

--- a/live-server/server/webrtc/webrtc_server_session.cpp
+++ b/live-server/server/webrtc/webrtc_server_session.cpp
@@ -1,74 +1,61 @@
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/experimental/awaitable_operators.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <iostream>
 #include <variant>
 
-#include <boost/asio/experimental/awaitable_operators.hpp>
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/ip/udp.hpp>
 using namespace boost::asio::experimental::awaitable_operators;
 
-#include "spdlog/spdlog.h"
-#include "json/json.h"
-
-#include "webrtc_server_session.hpp"
-#include "webrtc_server.hpp"
-
-#include "base/utils/utils.h"
-#include "base/thread/thread_worker.hpp"
-#include "config/config.h"
-#include "config/app_config.h"
-
 #include "app/app.h"
-
-#include "server/stun/protocol/stun_msg.h"
-#include "server/stun/protocol/stun_binding_response_msg.hpp"
-#include "server/stun/protocol/stun_mapped_address_attr.h"
-#include "bridge/media_bridge.hpp"
-#include "protocol/http/websocket/websocket_packet.hpp"
-
-#include "protocol/http/http_request.hpp"
-#include "protocol/http/http_response.hpp"
-
-#include "dtls/dtls_cert.h"
-#include "dtls/boringssl_session.h"
-
-#include "webrtc_media_source.hpp"
-#include "webrtc_server_session.hpp"
-
-#include "core/source_manager.hpp"
-#include "codec/h264/h264_codec.hpp"
-#include "server/session.hpp"
-
-#include "core/rtp_media_source.hpp"
-#include "core/rtp_media_sink.hpp"
-
-#include "protocol/rtp/rtp_packet.h"
-#include "protocol/sdp/attribute/common/dir.hpp"
-#include "protocol/rtp/rtp_h264_packet.h"
-#include "protocol/rtp/rtcp/rtcp_fb_pli.h"
-#include "protocol/rtp/rtcp/rtcp_sr.h"
-#include "protocol/rtp/rtcp/rtcp_rr.hpp"
-
 #include "app/play_app.h"
 #include "app/publish_app.h"
+#include "base/thread/thread_worker.hpp"
+#include "base/utils/utils.h"
+#include "bridge/media_bridge.hpp"
+#include "codec/h264/h264_codec.hpp"
+#include "config/app_config.h"
+#include "config/config.h"
+#include "core/rtp_media_sink.hpp"
+#include "core/rtp_media_source.hpp"
+#include "core/source_manager.hpp"
+#include "dtls/boringssl_session.h"
+#include "dtls/dtls_cert.h"
+#include "json/json.h"
+#include "protocol/http/http_request.hpp"
+#include "protocol/http/http_response.hpp"
+#include "protocol/http/websocket/websocket_packet.hpp"
+#include "protocol/rtp/rtcp/rtcp_fb_pli.h"
+#include "protocol/rtp/rtcp/rtcp_rr.hpp"
+#include "protocol/rtp/rtcp/rtcp_sr.h"
+#include "protocol/rtp/rtp_h264_packet.h"
+#include "protocol/rtp/rtp_packet.h"
+#include "protocol/sdp/attribute/common/dir.hpp"
+#include "server/session.hpp"
+#include "server/stun/protocol/stun_binding_response_msg.hpp"
+#include "server/stun/protocol/stun_mapped_address_attr.h"
+#include "server/stun/protocol/stun_msg.h"
+#include "spdlog/spdlog.h"
+#include "webrtc_media_source.hpp"
+#include "webrtc_server.hpp"
+#include "webrtc_server_session.hpp"
 
 using namespace mms;
-WebRtcServerSession::WebRtcServerSession(ThreadWorker *worker) : 
-                                         StreamSession(worker), 
-                                         worker_(worker),
-                                         ws_msgs_coroutine_exited_(worker->get_io_context()),
-                                         udp_msgs_channel_(worker->get_io_context()), 
-                                         alive_timeout_timer_(worker->get_io_context()), 
-                                         play_sdp_timeout_timer_(worker->get_io_context()),
-                                         send_rtp_pkts_channel_(worker->get_io_context()), 
-                                         send_rtcp_fb_pkts_channel_(worker->get_io_context()), 
-                                         send_rtcp_pkts_channel_(worker->get_io_context()), 
-                                         send_funcs_channel_(worker->get_io_context()),
-                                         send_pli_timer_(worker->get_io_context()), 
-                                         wg_(worker)
-{
-    send_buf_ = std::make_unique<uint8_t[]>(1024*1024);
-    enc_buf_ = std::make_unique<uint8_t[]>(1024*1024);
+WebRtcServerSession::WebRtcServerSession(ThreadWorker *worker)
+    : StreamSession(worker),
+      worker_(worker),
+      ws_msgs_coroutine_exited_(worker->get_io_context()),
+      udp_msgs_channel_(worker->get_io_context()),
+      alive_timeout_timer_(worker->get_io_context()),
+      play_sdp_timeout_timer_(worker->get_io_context()),
+      send_rtp_pkts_channel_(worker->get_io_context()),
+      send_rtcp_fb_pkts_channel_(worker->get_io_context()),
+      send_rtcp_pkts_channel_(worker->get_io_context()),
+      send_funcs_channel_(worker->get_io_context()),
+      send_pli_timer_(worker->get_io_context()),
+      wg_(worker) {
+    send_buf_ = std::make_unique<uint8_t[]>(1024 * 1024);
+    enc_buf_ = std::make_unique<uint8_t[]>(1024 * 1024);
 
     local_ice_ufrag_ = Utils::get_rand_str(4);
     local_ice_pwd_ = Utils::get_rand_str(24);
@@ -77,114 +64,114 @@ WebRtcServerSession::WebRtcServerSession(ThreadWorker *worker) :
 void WebRtcServerSession::start_alive_checker() {
     auto self(shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            alive_timeout_timer_.expires_from_now(std::chrono::seconds(5));
-            co_await alive_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                co_return;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                alive_timeout_timer_.expires_after(std::chrono::seconds(5));
+                co_await alive_timeout_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    co_return;
+                }
+                int64_t now_ms = Utils::get_current_ms();
+                CORE_DEBUG("session:{} checking alive...", get_session_name());
+                if (now_ms - last_active_time_ >= 50000) {  // 5秒没数据，超时
+                    co_return;
+                }
+                CORE_DEBUG("session:{} is alive", get_session_name());
             }
-            int64_t now_ms = Utils::get_current_ms();
-            CORE_DEBUG("session:{} checking alive...", get_session_name());
-            if (now_ms - last_active_time_ >= 50000) {//5秒没数据，超时
-                co_return;
-            }
-            CORE_DEBUG("session:{} is alive", get_session_name());
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
-void WebRtcServerSession::update_active_timestamp() {
-    last_active_time_ = Utils::get_current_ms();
-}
+void WebRtcServerSession::update_active_timestamp() { last_active_time_ = Utils::get_current_ms(); }
 
 boost::asio::awaitable<void> WebRtcServerSession::stop_alive_checker() {
     alive_timeout_timer_.cancel();
     co_return;
 }
 
-boost::asio::awaitable<void> WebRtcServerSession::async_process_udp_msg(UdpSocket *sock, std::unique_ptr<uint8_t[]> data, size_t len, boost::asio::ip::udp::endpoint &remote_ep)
-{
-    co_await udp_msgs_channel_.async_send(boost::system::error_code{}, sock, std::move(data), len, remote_ep, boost::asio::use_awaitable);
+boost::asio::awaitable<void> WebRtcServerSession::async_process_udp_msg(
+    UdpSocket *sock, std::unique_ptr<uint8_t[]> data, size_t len, boost::asio::ip::udp::endpoint &remote_ep) {
+    co_await udp_msgs_channel_.async_send(boost::system::error_code{}, sock, std::move(data), len, remote_ep,
+                                          boost::asio::use_awaitable);
     co_return;
 }
 
-WebRtcServerSession::~WebRtcServerSession()
-{
-    CORE_DEBUG("destroy WebRtcServerSession");
-}
+WebRtcServerSession::~WebRtcServerSession() { CORE_DEBUG("destroy WebRtcServerSession"); }
 
-std::string WebRtcServerSession::get_local_ip() const {
-    return local_ip_;
-}
+std::string WebRtcServerSession::get_local_ip() const { return local_ip_; }
 
-void WebRtcServerSession::set_local_ip(const std::string & v) {
-    local_ip_ = v;
-}
+void WebRtcServerSession::set_local_ip(const std::string &v) { local_ip_ = v; }
 
-uint16_t WebRtcServerSession::get_udp_port() const {
-    return udp_port_;
-}
+uint16_t WebRtcServerSession::get_udp_port() const { return udp_port_; }
 
-void WebRtcServerSession::set_udp_port(uint16_t v) {
-    udp_port_ = v;
-}
+void WebRtcServerSession::set_udp_port(uint16_t v) { udp_port_ = v; }
 
 void WebRtcServerSession::start_process_recv_udp_msg() {
     auto self(this->shared_from_this());
     dtls_boringssl_session_ = std::make_shared<DtlsBoringSSLSession>(worker_, *this);
-    
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        dtls_boringssl_session_->on_handshake_done(std::bind(&WebRtcServerSession::on_dtls_handshake_done, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-        auto ret = co_await dtls_boringssl_session_->do_handshake(DtlsBoringSSLSession::mode_server, dtls_cert_);
-        if (0 != ret) {// handshake failed
+
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            dtls_boringssl_session_->on_handshake_done(
+                std::bind(&WebRtcServerSession::on_dtls_handshake_done, this, std::placeholders::_1,
+                          std::placeholders::_2, std::placeholders::_3));
+            auto ret =
+                co_await dtls_boringssl_session_->do_handshake(DtlsBoringSSLSession::mode_server, dtls_cert_);
+            if (0 != ret) {  // handshake failed
+                co_return;
+            }
+            // dtls握手成功，启动rtcp数据发送
+            start_rtcp_fb_sender();
+            start_rtcp_sender();
+            if (is_player_) {
+                start_rtp_sender();
+            } else if (is_publisher_) {
+                start_pli_sender();
+            }
             co_return;
-        }
-        // dtls握手成功，启动rtcp数据发送
-        start_rtcp_fb_sender();
-        start_rtcp_sender();
-        if (is_player_) {
-            start_rtp_sender();
-        } else if (is_publisher_) {
-            start_pli_sender();
-        }
-        co_return;
-    }, boost::asio::detached);
+        },
+        boost::asio::detached);
 
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            auto [sock, udp_msg, len, remote_ep] = co_await udp_msgs_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                auto [sock, udp_msg, len, remote_ep] = co_await udp_msgs_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
+                }
+                update_active_timestamp();
+                UDP_MSG_TYPE msg_type = detect_msg_type(udp_msg.get(), len);
+                if (UDP_MSG_DTLS == msg_type) {
+                    if (!co_await process_dtls_packet(std::move(udp_msg), len, sock, remote_ep)) {
+                        continue;
+                    }
+                } else if (UDP_MSG_RTP == msg_type) {
+                    if (!co_await process_srtp_packet(std::move(udp_msg), len, sock, remote_ep)) {
+                        continue;
+                    }
+                }
             }
-            update_active_timestamp();
-            UDP_MSG_TYPE msg_type = detect_msg_type(udp_msg.get(), len);
-            if (UDP_MSG_DTLS == msg_type) {
-                if (!co_await process_dtls_packet(std::move(udp_msg), len, sock, remote_ep))
-                {
-                    continue;
-                }
-            } else if (UDP_MSG_RTP == msg_type) {
-                if (!co_await process_srtp_packet(std::move(udp_msg), len, sock, remote_ep))
-                {
-                    continue;
-                }
-            } 
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
 boost::asio::awaitable<void> WebRtcServerSession::stop_process_recv_udp_msg() {
@@ -195,36 +182,41 @@ boost::asio::awaitable<void> WebRtcServerSession::stop_process_recv_udp_msg() {
     if (dtls_boringssl_session_) {
         co_await dtls_boringssl_session_->close();
     }
-    
+
     co_return;
 }
 
 void WebRtcServerSession::start_pli_sender() {
     auto self(this->shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            send_pli_timer_.expires_from_now(std::chrono::milliseconds(2000));//2s发一次
-            co_await send_pli_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                send_pli_timer_.expires_after(std::chrono::milliseconds(2000));  // 2s发一次
+                co_await send_pli_timer_.async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            std::shared_ptr<RtcpFbPli> pli_pkt = std::make_shared<RtcpFbPli>();
-            pli_pkt->set_ssrc(video_ssrc_);
-            pli_pkt->set_media_source_ssrc(video_ssrc_);
-            co_await send_rtcp_fb_pkts_channel_.async_send(boost::system::error_code{}, pli_pkt, boost::asio::use_awaitable);            
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+                std::shared_ptr<RtcpFbPli> pli_pkt = std::make_shared<RtcpFbPli>();
+                pli_pkt->set_ssrc(video_ssrc_);
+                pli_pkt->set_media_source_ssrc(video_ssrc_);
+                co_await send_rtcp_fb_pkts_channel_.async_send(boost::system::error_code{}, pli_pkt,
+                                                               boost::asio::use_awaitable);
+            }
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
-boost::asio::awaitable<void>  WebRtcServerSession::stop_pli_sender() {
+boost::asio::awaitable<void> WebRtcServerSession::stop_pli_sender() {
     send_pli_timer_.cancel();
     co_return;
 }
@@ -232,42 +224,48 @@ boost::asio::awaitable<void>  WebRtcServerSession::stop_pli_sender() {
 void WebRtcServerSession::start_rtp_sender() {
     auto self(this->shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        spdlog::info("rtp sender running");
-        while (1) {
-            auto rtp_pkts = co_await send_rtp_pkts_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
-            }
-
-            for (auto rtp_pkt : rtp_pkts) {
-                // if (rtp_pkt->get_pt() == video_pt_) {
-                //     spdlog::info("recv pt:{:x}, num:{}", rtp_pkt->get_pt(), rtp_pkt->get_seq_num());
-                // }
-                
-                auto rtp_size = rtp_pkt->encode((uint8_t*)send_buf_.get(), 1024*1024);
-                size_t enc_buf_size = 1024*1024;
-                auto r = srtp_session_.protect_srtp((uint8_t*)send_buf_.get(), rtp_size, (uint8_t*)enc_buf_.get(), enc_buf_size);
-                if (r < 0) {
-                    spdlog::error("protect srtp failed, rtp_size:{}, ret:{}, seq:{}, pt:{:x}", rtp_size, r, rtp_pkt->get_seq_num(), rtp_pkt->get_pt());
-                    co_return;
-                } else if (r == 0) {
-                    continue;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            spdlog::info("rtp sender running");
+            while (1) {
+                auto rtp_pkts = co_await send_rtp_pkts_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
                 }
 
-                if (!co_await send_rtp_socket_->send_to(enc_buf_.get(), enc_buf_size, peer_ep)) {
-                    co_return;
+                for (auto rtp_pkt : rtp_pkts) {
+                    // if (rtp_pkt->get_pt() == video_pt_) {
+                    //     spdlog::info("recv pt:{:x}, num:{}", rtp_pkt->get_pt(), rtp_pkt->get_seq_num());
+                    // }
+
+                    auto rtp_size = rtp_pkt->encode((uint8_t *)send_buf_.get(), 1024 * 1024);
+                    size_t enc_buf_size = 1024 * 1024;
+                    auto r = srtp_session_.protect_srtp((uint8_t *)send_buf_.get(), rtp_size,
+                                                        (uint8_t *)enc_buf_.get(), enc_buf_size);
+                    if (r < 0) {
+                        spdlog::error("protect srtp failed, rtp_size:{}, ret:{}, seq:{}, pt:{:x}", rtp_size,
+                                      r, rtp_pkt->get_seq_num(), rtp_pkt->get_pt());
+                        co_return;
+                    } else if (r == 0) {
+                        continue;
+                    }
+
+                    if (!co_await send_rtp_socket_->send_to(enc_buf_.get(), enc_buf_size, peer_ep)) {
+                        co_return;
+                    }
+                    update_active_timestamp();
                 }
-                update_active_timestamp();
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        close();
-        wg_.done();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            close();
+            wg_.done();
+        });
 }
 
 boost::asio::awaitable<void> WebRtcServerSession::stop_rtp_sender() {
@@ -280,39 +278,44 @@ boost::asio::awaitable<void> WebRtcServerSession::stop_rtp_sender() {
 void WebRtcServerSession::start_rtcp_fb_sender() {
     auto self(this->shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        fb_buf_ = std::make_unique<uint8_t[]>(65536);
-        enc_fb_buf_ = std::make_unique<uint8_t[]>(65536);
-        while (1) {
-            auto fb_pkt = co_await send_rtcp_fb_pkts_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
-            }
-
-            if (fb_pkt) {
-                auto fb_size = fb_pkt->encode((uint8_t*)fb_buf_.get(), 65536);
-                size_t enc_fb_buf_size = 65536;
-
-                auto r = srtp_session_.protect_srtcp((uint8_t*)fb_buf_.get(), fb_size, (uint8_t*)enc_fb_buf_.get(), enc_fb_buf_size);
-                if (r < 0) {
-                    spdlog::error("protect srtcp failed");
-                    co_return;
-                } else if (r == 0) {
-                    continue;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            fb_buf_ = std::make_unique<uint8_t[]>(65536);
+            enc_fb_buf_ = std::make_unique<uint8_t[]>(65536);
+            while (1) {
+                auto fb_pkt = co_await send_rtcp_fb_pkts_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
                 }
 
-                if (!co_await send_rtp_socket_->send_to(enc_fb_buf_.get(), enc_fb_buf_size, peer_ep)) {
-                    co_return;
+                if (fb_pkt) {
+                    auto fb_size = fb_pkt->encode((uint8_t *)fb_buf_.get(), 65536);
+                    size_t enc_fb_buf_size = 65536;
+
+                    auto r = srtp_session_.protect_srtcp((uint8_t *)fb_buf_.get(), fb_size,
+                                                         (uint8_t *)enc_fb_buf_.get(), enc_fb_buf_size);
+                    if (r < 0) {
+                        spdlog::error("protect srtcp failed");
+                        co_return;
+                    } else if (r == 0) {
+                        continue;
+                    }
+
+                    if (!co_await send_rtp_socket_->send_to(enc_fb_buf_.get(), enc_fb_buf_size, peer_ep)) {
+                        co_return;
+                    }
                 }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
 boost::asio::awaitable<void> WebRtcServerSession::stop_rtcp_fb_sender() {
@@ -322,42 +325,46 @@ boost::asio::awaitable<void> WebRtcServerSession::stop_rtcp_fb_sender() {
     co_return;
 }
 
-
 void WebRtcServerSession::start_rtcp_sender() {
     auto self(this->shared_from_this());
     wg_.add(1);
-    boost::asio::co_spawn(worker_->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        auto send_buf = std::make_unique<uint8_t[]>(65536);
-        auto encoded_buf = std::make_unique<uint8_t[]>(65536);
-        while (1) {
-            auto rtcp_pkt = co_await send_rtcp_pkts_channel_.async_receive(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (ec) {
-                break;
-            }
-
-            if (rtcp_pkt) {
-                auto rtcp_size = rtcp_pkt->encode((uint8_t*)send_buf.get(), 65536);
-                size_t enc_rtcp_buf_size = 65536;
-                auto r = srtp_session_.protect_srtcp((uint8_t*)send_buf.get(), rtcp_size, (uint8_t*)encoded_buf.get(), enc_rtcp_buf_size);
-                if (r < 0) {
-                    spdlog::error("protect srtcp failed");
-                    co_return;
-                } else if (r == 0) {
-                    continue;
+    boost::asio::co_spawn(
+        worker_->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            auto send_buf = std::make_unique<uint8_t[]>(65536);
+            auto encoded_buf = std::make_unique<uint8_t[]>(65536);
+            while (1) {
+                auto rtcp_pkt = co_await send_rtcp_pkts_channel_.async_receive(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (ec) {
+                    break;
                 }
 
-                if (!co_await send_rtp_socket_->send_to(encoded_buf.get(), enc_rtcp_buf_size, peer_ep)) {
-                    co_return;
+                if (rtcp_pkt) {
+                    auto rtcp_size = rtcp_pkt->encode((uint8_t *)send_buf.get(), 65536);
+                    size_t enc_rtcp_buf_size = 65536;
+                    auto r = srtp_session_.protect_srtcp((uint8_t *)send_buf.get(), rtcp_size,
+                                                         (uint8_t *)encoded_buf.get(), enc_rtcp_buf_size);
+                    if (r < 0) {
+                        spdlog::error("protect srtcp failed");
+                        co_return;
+                    } else if (r == 0) {
+                        continue;
+                    }
+
+                    if (!co_await send_rtp_socket_->send_to(encoded_buf.get(), enc_rtcp_buf_size, peer_ep)) {
+                        co_return;
+                    }
                 }
             }
-        }
-        co_return;
-    }, [this, self](std::exception_ptr exp) {
-        (void)exp;
-        wg_.done();
-        close();
-    });
+            co_return;
+        },
+        [this, self](std::exception_ptr exp) {
+            (void)exp;
+            wg_.done();
+            close();
+        });
 }
 
 boost::asio::awaitable<void> WebRtcServerSession::stop_rtcp_sender() {
@@ -367,10 +374,10 @@ boost::asio::awaitable<void> WebRtcServerSession::stop_rtcp_sender() {
     co_return;
 }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_ptr<HttpRequest> req, std::shared_ptr<HttpResponse> resp)
-{
-    auto & query_params = req->get_query_params();
-    for (auto & p : query_params) {
+boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_ptr<HttpRequest> req,
+                                                                   std::shared_ptr<HttpResponse> resp) {
+    auto &query_params = req->get_query_params();
+    for (auto &p : query_params) {
         set_param(p.first, p.second);
     }
 
@@ -391,7 +398,7 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_p
         co_await resp->write_header(403, "Forbidden");
         close();
         co_return false;
-    } 
+    }
     auto sdp = req->get_body();
     auto play_app = std::static_pointer_cast<PlayApp>(get_app());
     if (!play_app) {
@@ -411,18 +418,15 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_p
 
     auto self(std::static_pointer_cast<StreamSession>(shared_from_this()));
     is_publisher_ = true;
-    webrtc_media_source_ = std::make_shared<WebRtcMediaSource>(get_worker(), 
-                                                               std::weak_ptr<StreamSession>(self), 
-                                                               publish_app);     
+    webrtc_media_source_ =
+        std::make_shared<WebRtcMediaSource>(get_worker(), std::weak_ptr<StreamSession>(self), publish_app);
     std::string answer_sdp = webrtc_media_source_->process_publish_sdp(sdp);
     if (answer_sdp.empty()) {
         CORE_ERROR("process publish sdp failed");
         co_return false;
     }
 
-    if (!SourceManager::get_instance().add_source(get_domain_name(), 
-                                                  get_app_name(),
-                                                  get_stream_name(),
+    if (!SourceManager::get_instance().add_source(get_domain_name(), get_app_name(), get_stream_name(),
                                                   webrtc_media_source_)) {
         CORE_ERROR("add webrtc source failed.");
         co_return false;
@@ -431,7 +435,7 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_p
     video_ssrc_ = webrtc_media_source_->get_video_ssrc();
     audio_ssrc_ = webrtc_media_source_->get_audio_ssrc();
     start_process_recv_udp_msg();
-    
+
     resp->add_header("Content-Type", "application/sdp");
     if (!co_await resp->write_header(201, "Created")) {
         co_return false;
@@ -445,10 +449,10 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whip_req(std::shared_p
     co_return true;
 }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_ptr<HttpRequest> req, std::shared_ptr<HttpResponse> resp)
-{
-    auto & query_params = req->get_query_params();
-    for (auto & p : query_params) {
+boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_ptr<HttpRequest> req,
+                                                                   std::shared_ptr<HttpResponse> resp) {
+    auto &query_params = req->get_query_params();
+    for (auto &p : query_params) {
         set_param(p.first, p.second);
     }
 
@@ -469,7 +473,7 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
         co_await resp->write_header(403, "Forbidden");
         close();
         co_return false;
-    } 
+    }
 
     auto play_app = std::static_pointer_cast<PlayApp>(get_app());
     if (!play_app) {
@@ -483,12 +487,13 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
 
     auto self(std::static_pointer_cast<WebRtcServerSession>(shared_from_this()));
     // 1.本机查找
-    auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
+    auto source =
+        SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
     if (source) {
         spdlog::info("find source from local");
     }
 
-    if (!source) {// 2.本地配置查找外部回源
+    if (!source) {  // 2.本地配置查找外部回源
         source = co_await publish_app->find_media_source(self);
     }
     // 3.到media center中心查找
@@ -497,13 +502,14 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
     // }
 
     if (!source) {
-        //真找不到源流了，应该是没在播
+        // 真找不到源流了，应该是没在播
         co_return false;
     }
 
     std::shared_ptr<MediaBridge> bridge;
     if (source->get_media_type() != "webrtc{rtp[es]}") {
-        bridge = source->get_or_create_bridge(source->get_media_type() + "-webrtc{rtp[es]}", publish_app, stream_name_);
+        bridge = source->get_or_create_bridge(source->get_media_type() + "-webrtc{rtp[es]}", publish_app,
+                                              stream_name_);
         if (!bridge) {
             co_return false;
         }
@@ -511,23 +517,27 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
     } else {
         spdlog::info("source is webrtc{rtp[es]}");
     }
-    
+
     is_player_ = true;
     rtp_media_sink_ = std::make_shared<RtpMediaSink>(get_worker());
 
-    rtp_media_sink_->set_video_pkts_cb([this](std::vector<std::shared_ptr<RtpPacket>> rtp_pkts)->boost::asio::awaitable<bool> {
-        co_await send_rtp_pkts_channel_.async_send(boost::system::error_code{}, rtp_pkts, boost::asio::use_awaitable);
-        co_return true;
-    });
+    rtp_media_sink_->set_video_pkts_cb(
+        [this](std::vector<std::shared_ptr<RtpPacket>> rtp_pkts) -> boost::asio::awaitable<bool> {
+            co_await send_rtp_pkts_channel_.async_send(boost::system::error_code{}, rtp_pkts,
+                                                       boost::asio::use_awaitable);
+            co_return true;
+        });
 
-    rtp_media_sink_->set_audio_pkts_cb([this](std::vector<std::shared_ptr<RtpPacket>> rtp_pkts)->boost::asio::awaitable<bool> {
-        co_await send_rtp_pkts_channel_.async_send(boost::system::error_code{}, rtp_pkts, boost::asio::use_awaitable);
-        co_return true;
-    });
+    rtp_media_sink_->set_audio_pkts_cb(
+        [this](std::vector<std::shared_ptr<RtpPacket>> rtp_pkts) -> boost::asio::awaitable<bool> {
+            co_await send_rtp_pkts_channel_.async_send(boost::system::error_code{}, rtp_pkts,
+                                                       boost::asio::use_awaitable);
+            co_return true;
+        });
 
     start_process_recv_udp_msg();
     source->add_media_sink(rtp_media_sink_);
-    //todo: 处理桥接的问题
+    // todo: 处理桥接的问题
     auto webrtc_source = std::static_pointer_cast<WebRtcMediaSource>(source);
     int32_t try_get_play_sdp_count = 0;
     std::shared_ptr<Sdp> play_sdp;
@@ -543,8 +553,9 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
         }
 
         boost::system::error_code ec;
-        play_sdp_timeout_timer_.expires_from_now(std::chrono::milliseconds(10));
-        co_await play_sdp_timeout_timer_.async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+        play_sdp_timeout_timer_.expires_after(std::chrono::milliseconds(10));
+        co_await play_sdp_timeout_timer_.async_wait(
+            boost::asio::redirect_error(boost::asio::use_awaitable, ec));
         if (ec) {
             break;
         }
@@ -557,7 +568,7 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
         close();
         co_return false;
     }
-    
+
     auto &medias = play_sdp->get_media_sdps();
     for (auto &media : medias) {
         media.set_ice_ufrag(IceUfrag(local_ice_ufrag_));
@@ -596,7 +607,7 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
 //     }
 
 //     const std::string &type = msg["type"].asString();
-//     if ("answer" != type) 
+//     if ("answer" != type)
 //     {
 //         co_return false;
 //     }
@@ -641,25 +652,22 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_whep_req(std::shared_p
 //     co_return true;
 // }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_stun_packet(std::shared_ptr<StunMsg> stun_msg, std::unique_ptr<uint8_t[]> data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep)
-{
+boost::asio::awaitable<bool> WebRtcServerSession::process_stun_packet(
+    std::shared_ptr<StunMsg> stun_msg, std::unique_ptr<uint8_t[]> data, size_t len, UdpSocket *sock,
+    const boost::asio::ip::udp::endpoint &remote_ep) {
     const std::string &pwd = get_local_ice_pwd();
-    if (!stun_msg->check_msg_integrity(data.get(), len, pwd))
-    {
+    if (!stun_msg->check_msg_integrity(data.get(), len, pwd)) {
         spdlog::error("check msg integrity failed");
         co_return false;
     }
 
-    if (!stun_msg->check_finger_print(data.get(), len))
-    {
+    if (!stun_msg->check_finger_print(data.get(), len)) {
         spdlog::error("check finger print failed.");
         co_return false;
     }
 
-    switch (stun_msg->type())
-    {
-        case STUN_BINDING_REQUEST:
-        {
+    switch (stun_msg->type()) {
+        case STUN_BINDING_REQUEST: {
             // 返回响应
             auto ret = co_await process_stun_binding_req(stun_msg, sock, remote_ep);
             co_return ret;
@@ -668,33 +676,31 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_stun_packet(std::share
     co_return false;
 }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_stun_binding_req(std::shared_ptr<StunMsg> stun_msg, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep)
-{
+boost::asio::awaitable<bool> WebRtcServerSession::process_stun_binding_req(
+    std::shared_ptr<StunMsg> stun_msg, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep) {
     StunBindingResponseMsg binding_resp(*stun_msg);
 
-    auto mapped_addr_attr = std::make_unique<StunMappedAddressAttr>(remote_ep.address().to_v4().to_uint(), remote_ep.port());
+    auto mapped_addr_attr =
+        std::make_unique<StunMappedAddressAttr>(remote_ep.address().to_v4().to_uint(), remote_ep.port());
     binding_resp.add_attr(std::move(mapped_addr_attr));
 
     // 校验完整性
     auto req_username_attr = stun_msg->get_username_attr();
-    if (!req_username_attr)
-    {
+    if (!req_username_attr) {
         co_return false;
     }
 
     const std::string &local_user_name = req_username_attr.value().get_local_user_name();
-    if (local_user_name.empty())
-    {
+    if (local_user_name.empty()) {
         co_return false;
     }
 
     const std::string &remote_user_name = req_username_attr.value().get_remote_user_name();
-    if (remote_user_name.empty())
-    {
+    if (remote_user_name.empty()) {
         co_return false;
     }
 
-    if (remote_user_name != remote_ice_ufrag_) //用户名与sdp中给的不一致
+    if (remote_user_name != remote_ice_ufrag_)  // 用户名与sdp中给的不一致
     {
         co_return false;
     }
@@ -704,40 +710,38 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_stun_binding_req(std::
     auto size = binding_resp.size(true, true);
     std::unique_ptr<uint8_t[]> data = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
     int32_t consumed = binding_resp.encode(data.get(), size, true, local_ice_pwd_, true);
-    if (consumed < 0)
-    { // todo:add log
+    if (consumed < 0) {  // todo:add log
         co_return false;
     }
 
-    if (!(co_await sock->send_to(data.get(), size, remote_ep)))
-    { // todo log error
+    if (!(co_await sock->send_to(data.get(), size, remote_ep))) {  // todo log error
         co_return false;
     }
     peer_ep = remote_ep;
     co_return true;
 }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_dtls_packet(std::unique_ptr<uint8_t[]> recv_data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep)
-{
+boost::asio::awaitable<bool> WebRtcServerSession::process_dtls_packet(
+    std::unique_ptr<uint8_t[]> recv_data, size_t len, UdpSocket *sock,
+    const boost::asio::ip::udp::endpoint &remote_ep) {
     co_return co_await dtls_boringssl_session_->process_dtls_packet(recv_data.get(), len, sock, remote_ep);
 }
 
-void WebRtcServerSession::set_dtls_cert(std::shared_ptr<DtlsCert> dtls_cert)
-{
-    dtls_cert_ = dtls_cert;
-}
+void WebRtcServerSession::set_dtls_cert(std::shared_ptr<DtlsCert> dtls_cert) { dtls_cert_ = dtls_cert; }
 
-void WebRtcServerSession::on_dtls_handshake_done(SRTPProtectionProfile profile, const std::string &srtp_recv_key, const std::string &srtp_send_key)
-{
+void WebRtcServerSession::on_dtls_handshake_done(SRTPProtectionProfile profile,
+                                                 const std::string &srtp_recv_key,
+                                                 const std::string &srtp_send_key) {
     if (!srtp_session_.init(profile, srtp_recv_key, srtp_send_key)) {
         spdlog::error("srtp session init failed");
     } else {
         spdlog::info("srtp session init succeed!!!");
-    }    
+    }
 }
 
-boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(std::unique_ptr<uint8_t[]> recv_data, size_t len, UdpSocket *sock, const boost::asio::ip::udp::endpoint &remote_ep)
-{
+boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(
+    std::unique_ptr<uint8_t[]> recv_data, size_t len, UdpSocket *sock,
+    const boost::asio::ip::udp::endpoint &remote_ep) {
     ((void)sock);
     ((void)remote_ep);
     ((void)recv_data);
@@ -745,21 +749,19 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(std::uniqu
     ((void)sock);
     uint8_t *data = recv_data.get();
     int out_len = 0;
-    if (RtpHeader::is_rtcp_packet(data, len)) 
-    {
+    if (RtpHeader::is_rtcp_packet(data, len)) {
         out_len = srtp_session_.unprotect_srtcp(data, len);
-        if (out_len < 0)
-        {
+        if (out_len < 0) {
             co_return false;
         }
 
         auto pt = RtcpHeader::parse_pt(data, len);
         switch (pt) {
-            case PT_RTCP_SR:{
+            case PT_RTCP_SR: {
                 RtcpSr rtcp_sr;
                 int32_t consumed = rtcp_sr.decode(data, len);
                 if (consumed <= 0) {
-                    co_return  false;
+                    co_return false;
                 }
 
                 auto ntp = Utils::get_ntp_time();
@@ -771,14 +773,17 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(std::uniqu
                     report.ssrc = video_ssrc_;
                     report.fraction_lost = 0;
                     report.cumulative_number_of_packets_lost = 0;
-                    report.extended_highest_sequence_number_received = video_extended_highest_sequence_number_received_;
+                    report.extended_highest_sequence_number_received =
+                        video_extended_highest_sequence_number_received_;
                     report.interarrival_jitter = video_interarrival_jitter_;
                     report.last_SR = video_last_sr_ntp_ >> 16;
                     report.delay_since_last_SR = (ntp >> 16) - (video_last_sr_sys_ntp_ >> 16);
                     rtcp_rr->add_reception_report_block(report);
-                    video_last_sr_ntp_ = ((uint64_t)rtcp_sr.ntp_timestamp_sec_ << 32) | (rtcp_sr.ntp_timestamp_psec_);
+                    video_last_sr_ntp_ =
+                        ((uint64_t)rtcp_sr.ntp_timestamp_sec_ << 32) | (rtcp_sr.ntp_timestamp_psec_);
                     video_last_sr_sys_ntp_ = ntp;
-                    co_await send_rtcp_pkts_channel_.async_send(boost::system::error_code{}, rtcp_rr, boost::asio::use_awaitable);     
+                    co_await send_rtcp_pkts_channel_.async_send(boost::system::error_code{}, rtcp_rr,
+                                                                boost::asio::use_awaitable);
                 } else if (rtcp_sr.header_.sender_ssrc == audio_ssrc_) {
                     recv_sr_packets_[audio_ssrc_] = rtcp_sr;
                     std::shared_ptr<RtcpRR> rtcp_rr = std::make_shared<RtcpRR>();
@@ -787,95 +792,93 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(std::uniqu
                     report.ssrc = audio_ssrc_;
                     report.fraction_lost = 0;
                     report.cumulative_number_of_packets_lost = 0;
-                    report.extended_highest_sequence_number_received = audio_extended_highest_sequence_number_received_;
+                    report.extended_highest_sequence_number_received =
+                        audio_extended_highest_sequence_number_received_;
                     report.interarrival_jitter = audio_interarrival_jitter_;
                     report.last_SR = audio_last_sr_ntp_ >> 16;
                     report.delay_since_last_SR = (ntp >> 16) - (audio_last_sr_sys_ntp_ >> 16);
                     rtcp_rr->add_reception_report_block(report);
-                    audio_last_sr_ntp_ = ((uint64_t)rtcp_sr.ntp_timestamp_sec_ << 32) | (rtcp_sr.ntp_timestamp_psec_);
+                    audio_last_sr_ntp_ =
+                        ((uint64_t)rtcp_sr.ntp_timestamp_sec_ << 32) | (rtcp_sr.ntp_timestamp_psec_);
                     audio_last_sr_sys_ntp_ = ntp;
-                    co_await send_rtcp_pkts_channel_.async_send(boost::system::error_code{}, rtcp_rr, boost::asio::use_awaitable);
+                    co_await send_rtcp_pkts_channel_.async_send(boost::system::error_code{}, rtcp_rr,
+                                                                boost::asio::use_awaitable);
                     // spdlog::info("audio rtp time:{}", rtcp_sr.rtp_time_/48000);
                 }
-                
+
                 break;
             }
-            default:{
+            default: {
                 break;
             }
         }
-    }
-    else if (RtpHeader::is_rtp(data, len))
-    {
+    } else if (RtpHeader::is_rtp(data, len)) {
         out_len = srtp_session_.unprotect_srtp(data, len);
-        if (out_len < 0)
-        {
+        if (out_len < 0) {
             co_return false;
         }
 
-        auto ssrc = RtpHeader::parse_ssrc(data, out_len);//todo 改成用ssrc来区分
-        if (ssrc == webrtc_media_source_->get_audio_ssrc())
-        {
+        auto ssrc = RtpHeader::parse_ssrc(data, out_len);  // todo 改成用ssrc来区分
+        if (ssrc == webrtc_media_source_->get_audio_ssrc()) {
             std::shared_ptr<RtpPacket> rtp_pkt = std::make_shared<RtpPacket>();
             int32_t consumed = rtp_pkt->decode_and_store(data, out_len);
-            if (consumed < 0)
-            {
+            if (consumed < 0) {
                 co_return false;
             }
 
-            uint64_t now_ms_in_timestamp_units = Utils::get_current_ms()*48;
+            uint64_t now_ms_in_timestamp_units = Utils::get_current_ms() * 48;
             if (audio_recv_in_timestamp_units_ != 0) {
                 int32_t sj = rtp_pkt->get_timestamp();
                 int32_t si = audio_recv_rtp_ts_;
                 auto rj = now_ms_in_timestamp_units;
                 auto ri = audio_recv_in_timestamp_units_;
-                int32_t di_j = (rj - ri ) - (sj - si);
-                int32_t jitter_i = audio_interarrival_jitter_ + (abs(di_j) - audio_interarrival_jitter_)/16;
+                int32_t di_j = (rj - ri) - (sj - si);
+                int32_t jitter_i = audio_interarrival_jitter_ + (abs(di_j) - audio_interarrival_jitter_) / 16;
                 audio_interarrival_jitter_ = jitter_i;
             }
             audio_recv_in_timestamp_units_ = now_ms_in_timestamp_units;
             audio_recv_rtp_ts_ = rtp_pkt->get_timestamp();
-            audio_extended_highest_sequence_number_received_ = rtp_pkt->get_seq_num();//todo add 1 to high byte
+            audio_extended_highest_sequence_number_received_ =
+                rtp_pkt->get_seq_num();  // todo add 1 to high byte
             std::vector<std::shared_ptr<RtpPacket>> pkts;
             pkts.push_back(rtp_pkt);
             co_return co_await webrtc_media_source_->on_audio_packets(pkts);
-        }
-        else if (ssrc == webrtc_media_source_->get_video_ssrc())
-        {   
+        } else if (ssrc == webrtc_media_source_->get_video_ssrc()) {
             std::shared_ptr<RtpPacket> rtp_pkt = std::make_shared<RtpPacket>();
             int32_t consumed = rtp_pkt->decode_and_store(data, out_len);
-            if (consumed < 0)
-            {
+            if (consumed < 0) {
                 co_return false;
             }
 
             if (first_rtp_video_ts_ == 0) {
                 first_rtp_video_ts_ = rtp_pkt->get_timestamp();
             }
-            
+
             // RtpMediaSource::on_video_packet(rtp_pkt);
             auto h264_nalu = rtp_h264_depacketizer_.on_packet(rtp_pkt);
             if (h264_nalu) {
                 uint32_t this_timestamp = h264_nalu->get_timestamp();
-                bool key = find_key_frame((this_timestamp - first_rtp_video_ts_)/90, h264_nalu);//todo 除90这个要根据sdp来计算，目前固定
+                bool key = find_key_frame((this_timestamp - first_rtp_video_ts_) / 90,
+                                          h264_nalu);  // todo 除90这个要根据sdp来计算，目前固定
                 if (key) {
                     CORE_DEBUG("WebRtcServerSession find key frame");
                 }
             }
 
-            uint64_t now_ms_in_timestamp_units = Utils::get_current_ms()*90;
+            uint64_t now_ms_in_timestamp_units = Utils::get_current_ms() * 90;
             if (video_recv_in_timestamp_units_ != 0) {
                 int32_t sj = rtp_pkt->get_timestamp();
                 int32_t si = video_recv_rtp_ts_;
                 auto rj = now_ms_in_timestamp_units;
                 auto ri = video_recv_in_timestamp_units_;
-                int32_t di_j = (rj - ri ) - (sj - si);
-                int32_t jitter_i = video_interarrival_jitter_ + (abs(di_j) - video_interarrival_jitter_)/16;
+                int32_t di_j = (rj - ri) - (sj - si);
+                int32_t jitter_i = video_interarrival_jitter_ + (abs(di_j) - video_interarrival_jitter_) / 16;
                 video_interarrival_jitter_ = jitter_i;
             }
             video_recv_in_timestamp_units_ = now_ms_in_timestamp_units;
             video_recv_rtp_ts_ = rtp_pkt->get_timestamp();
-            video_extended_highest_sequence_number_received_ = rtp_pkt->get_seq_num();//todo add 1 to high byte
+            video_extended_highest_sequence_number_received_ =
+                rtp_pkt->get_seq_num();  // todo add 1 to high byte
             std::vector<std::shared_ptr<RtpPacket>> pkts;
             pkts.push_back(rtp_pkt);
             co_return co_await webrtc_media_source_->on_video_packets(pkts);
@@ -884,29 +887,29 @@ boost::asio::awaitable<bool> WebRtcServerSession::process_srtp_packet(std::uniqu
     co_return false;
 }
 
-bool WebRtcServerSession::find_key_frame(uint32_t timestamp, std::shared_ptr<RtpH264NALU> & nalu) {
+bool WebRtcServerSession::find_key_frame(uint32_t timestamp, std::shared_ptr<RtpH264NALU> &nalu) {
     (void)timestamp;
     bool is_key = false;
-    auto & pkts = nalu->get_rtp_pkts();
-    for (auto  it = pkts.begin(); it != pkts.end(); it++) {
+    auto &pkts = nalu->get_rtp_pkts();
+    for (auto it = pkts.begin(); it != pkts.end(); it++) {
         auto pkt = it->second;
         // const uint8_t *pkt_buf = (const uint8_t*)pkt->get_payload().data();
 
         H264RtpPktInfo pkt_info;
         pkt_info.parse(pkt->get_payload().data(), pkt->get_payload().size());
-        
+
         if (pkt_info.is_stap_a()) {
             std::string_view payload = pkt->get_payload();
             const char *data = payload.data() + 1;
             size_t pos = 1;
-            
-            while (pos < payload.size()) {  
+
+            while (pos < payload.size()) {
                 uint16_t nalu_size = ntohs(*(uint16_t *)data);
                 uint8_t nalu_type = *(data + 2) & 0x1F;
                 if (nalu_type == H264NaluTypeIDR) {
                     is_key = true;
                 }
-                
+
                 pos += 2 + nalu_size;
                 data += 2 + nalu_size;
             }
@@ -922,7 +925,7 @@ bool WebRtcServerSession::find_key_frame(uint32_t timestamp, std::shared_ptr<Rtp
                             is_key = true;
                         }
                     }
-                    
+
                     if (pkt_info.is_end_fu()) {
                         break;
                     }
@@ -934,63 +937,67 @@ bool WebRtcServerSession::find_key_frame(uint32_t timestamp, std::shared_ptr<Rtp
                     }
                 } while (pkt_info.get_type() == H264_RTP_PAYLOAD_FU_A && it != pkts.end());
             }
-        } 
+        }
     }
     return is_key;
 }
 
-void WebRtcServerSession::service()
-{
+void WebRtcServerSession::service() {
     start_alive_checker();
     return;
 }
 
-void WebRtcServerSession::close()
-{
+void WebRtcServerSession::close() {
     if (closed_.test_and_set(std::memory_order_acquire)) {
         return;
     }
 
     auto self(this->shared_from_this());
-    boost::asio::co_spawn(get_worker()->get_io_context(), [this, self]()->boost::asio::awaitable<void> {
-        CORE_DEBUG("closing webrtc sever session, step:stop_process_recv_udp_msg");
-        co_await stop_process_recv_udp_msg();
-        CORE_DEBUG("closing webrtc sever session, step:stop_pli_sender");
-        co_await stop_pli_sender();
-        CORE_DEBUG("closing webrtc sever session, step:stop_alive_checker");
-        co_await stop_alive_checker();
-        CORE_DEBUG("closing webrtc sever session, step:stop_rtp_sender");
-        co_await stop_rtp_sender();
-        CORE_DEBUG("closing webrtc sever session, step:stop_rtcp_fb_sender");
-        co_await stop_rtcp_fb_sender();
-        CORE_DEBUG("closing webrtc sever session, step:stop_rtcp_sender");
-        co_await stop_rtcp_sender();
-        co_await wg_.wait();
-        boost::system::error_code ec;
-        play_sdp_timeout_timer_.cancel();
-        
-        if (rtp_media_sink_) {
-            auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(), get_stream_name());
-            if (source) {
-                source->remove_media_sink(rtp_media_sink_);
-                rtp_media_sink_->close();
-                rtp_media_sink_.reset();
+    boost::asio::co_spawn(
+        get_worker()->get_io_context(),
+        [this, self]() -> boost::asio::awaitable<void> {
+            CORE_DEBUG("closing webrtc sever session, step:stop_process_recv_udp_msg");
+            co_await stop_process_recv_udp_msg();
+            CORE_DEBUG("closing webrtc sever session, step:stop_pli_sender");
+            co_await stop_pli_sender();
+            CORE_DEBUG("closing webrtc sever session, step:stop_alive_checker");
+            co_await stop_alive_checker();
+            CORE_DEBUG("closing webrtc sever session, step:stop_rtp_sender");
+            co_await stop_rtp_sender();
+            CORE_DEBUG("closing webrtc sever session, step:stop_rtcp_fb_sender");
+            co_await stop_rtcp_fb_sender();
+            CORE_DEBUG("closing webrtc sever session, step:stop_rtcp_sender");
+            co_await stop_rtcp_sender();
+            co_await wg_.wait();
+            boost::system::error_code ec;
+            play_sdp_timeout_timer_.cancel();
+
+            if (rtp_media_sink_) {
+                auto source = SourceManager::get_instance().get_source(get_domain_name(), get_app_name(),
+                                                                       get_stream_name());
+                if (source) {
+                    source->remove_media_sink(rtp_media_sink_);
+                    rtp_media_sink_->close();
+                    rtp_media_sink_.reset();
+                }
             }
-        } 
-        
-        if (webrtc_media_source_) {
-            SourceManager::get_instance().remove_source(get_domain_name(), get_app_name(), get_stream_name());
-            webrtc_media_source_->close();
-            webrtc_media_source_.reset();
-        }
-        
-        if (close_handler_) {
-            close_handler_->on_webrtc_session_close(std::static_pointer_cast<WebRtcServerSession>(shared_from_this()));
-        }
-        
-        CORE_DEBUG("close webrtc sever session done");
-        co_return;
-    }, boost::asio::detached);
+
+            if (webrtc_media_source_) {
+                SourceManager::get_instance().remove_source(get_domain_name(), get_app_name(),
+                                                            get_stream_name());
+                webrtc_media_source_->close();
+                webrtc_media_source_.reset();
+            }
+
+            if (close_handler_) {
+                close_handler_->on_webrtc_session_close(
+                    std::static_pointer_cast<WebRtcServerSession>(shared_from_this()));
+            }
+
+            CORE_DEBUG("close webrtc sever session done");
+            co_return;
+        },
+        boost::asio::detached);
 }
 
 boost::asio::awaitable<bool> WebRtcServerSession::send_udp_msg(const uint8_t *data, size_t len) {

--- a/live-server/service/dns/dns_service.cpp
+++ b/live-server/service/dns/dns_service.cpp
@@ -3,54 +3,51 @@
  * @Date: 2022-12-23 23:36:16
  * @LastEditTime: 2023-08-27 09:59:49
  * @LastEditors: jbl19860422
- * @Description: 
+ * @Description:
  * @FilePath: \mms\mms\dns\dns_service.cpp
- * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved. 
+ * Copyright (c) 2023 by jbl19860422@gitee.com, All Rights Reserved.
  */
-#include <boost/asio.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/asio/spawn.hpp>
-#include <boost/asio/experimental/awaitable_operators.hpp>
-
 #include "dns_service.hpp"
+
+#include <boost/asio.hpp>
+#include <boost/asio/experimental/awaitable_operators.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include "log/log.h"
 
 using namespace mms;
 DnsService DnsService::instance_;
-DnsService & DnsService::get_instance() {
-    return instance_;
-}
+DnsService& DnsService::get_instance() { return instance_; }
 
-DnsService::DnsService() {
-    
-}
+DnsService::DnsService() {}
 
-DnsService::~DnsService() {
-    
-}
+DnsService::~DnsService() {}
 
 void DnsService::start() {
     worker_.start();
     refresh_timer_ = std::make_unique<boost::asio::deadline_timer>(worker_.get_io_context());
-    boost::asio::co_spawn(worker_.get_io_context(), [this]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        while (1) {
-            refresh_timer_->expires_from_now(boost::posix_time::milliseconds(resolve_interval_ms_));
-            co_await refresh_timer_->async_wait(boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-            if (boost::asio::error::operation_aborted == ec) {
-                break;
-            }
+    boost::asio::co_spawn(
+        worker_.get_io_context(),
+        [this]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            while (1) {
+                refresh_timer_->expires_from_now(boost::posix_time::milliseconds(resolve_interval_ms_));
+                co_await refresh_timer_->async_wait(
+                    boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+                if (boost::asio::error::operation_aborted == ec) {
+                    break;
+                }
 
-            std::lock_guard<std::recursive_mutex> lck(lock_);
-            for (auto & pair : domain_ips_) {
-                const std::string & domain = pair.first;
-                refresh(domain);
+                std::lock_guard<std::recursive_mutex> lck(lock_);
+                for (auto& pair : domain_ips_) {
+                    const std::string& domain = pair.first;
+                    refresh(domain);
+                }
             }
-        }
-        co_return;
-    }, [this](std::exception_ptr exp) {
-        ((void)exp);
-    });
+            co_return;
+        },
+        [this](std::exception_ptr exp) { ((void)exp); });
 }
 
 void DnsService::stop() {
@@ -58,7 +55,7 @@ void DnsService::stop() {
     worker_.stop();
 }
 
-void DnsService::add_domain(const std::string & domain) {
+void DnsService::add_domain(const std::string& domain) {
     bool new_add = false;
     {
         std::lock_guard<std::recursive_mutex> lck(lock_);
@@ -66,7 +63,7 @@ void DnsService::add_domain(const std::string & domain) {
         if (it == domain_ips_.end()) {
             domain_ips_[domain];
             new_add = true;
-        }  
+        }
     }
 
     if (new_add) {
@@ -75,12 +72,12 @@ void DnsService::add_domain(const std::string & domain) {
     }
 }
 
-void DnsService::remove_domain(const std::string & domain) {
+void DnsService::remove_domain(const std::string& domain) {
     std::lock_guard<std::recursive_mutex> lck(lock_);
     domain_ips_.erase(domain);
 }
 
-std::optional<std::string> DnsService::get_ip(const std::string & domain) {
+std::optional<std::string> DnsService::get_ip(const std::string& domain) {
     std::lock_guard<std::recursive_mutex> lck(lock_);
     auto it = domain_ips_.find(domain);
     if (it == domain_ips_.end() || it->second.size() <= 0) {
@@ -90,11 +87,11 @@ std::optional<std::string> DnsService::get_ip(const std::string & domain) {
     }
 
     srand(time(0));
-    int index = rand()%(it->second.size());
+    int index = rand() % (it->second.size());
     return it->second[index];
 }
 
-std::vector<std::string> DnsService::get_ips(const std::string & domain) {
+std::vector<std::string> DnsService::get_ips(const std::string& domain) {
     std::lock_guard<std::recursive_mutex> lck(lock_);
     auto it = domain_ips_.find(domain);
     if (it == domain_ips_.end()) {
@@ -103,52 +100,48 @@ std::vector<std::string> DnsService::get_ips(const std::string & domain) {
     return it->second;
 }
 
-void DnsService::set_resolve_interval(int ms) {
-    resolve_interval_ms_ = ms;
-}
+void DnsService::set_resolve_interval(int ms) { resolve_interval_ms_ = ms; }
 
-void DnsService::refresh(const std::string & domain) {
-    boost::asio::co_spawn(worker_.get_io_context(), [this, domain]()->boost::asio::awaitable<void> {
-        boost::system::error_code ec;
-        boost::asio::ip::tcp::resolver slv(worker_.get_io_context());
-        boost::asio::ip::tcp::resolver::query qry(domain, boost::lexical_cast<std::string>(0));
-        auto it = co_await slv.async_resolve(qry, boost::asio::redirect_error(boost::asio::use_awaitable, ec));
-        if (ec) {
-            co_return;
-        }
-
-        boost::asio::ip::tcp::resolver::iterator end;
-        if (it == end) {//直接为空，则不去更新
-            co_return;
-        }
-
-        {
-            std::lock_guard<std::recursive_mutex> lck(lock_);
-            auto it_domain = domain_ips_.find(domain);
-            if (it_domain == domain_ips_.end()) {
+void DnsService::refresh(const std::string& domain) {
+    boost::asio::co_spawn(
+        worker_.get_io_context(),
+        [this, domain]() -> boost::asio::awaitable<void> {
+            boost::system::error_code ec;
+            boost::asio::ip::tcp::resolver slv(worker_.get_io_context());
+            auto results = co_await slv.async_resolve(
+                domain, "0", boost::asio::redirect_error(boost::asio::use_awaitable, ec));
+            if (ec) {
                 co_return;
             }
 
-            auto & ips = it_domain->second;
-            ips.clear();
-            for (; it != end; it++)
-            {
-                ips.push_back((*it).endpoint().address().to_string());
+            if (results.empty()) {
+                co_return;
             }
-        }
-        co_return;
-    }, boost::asio::detached);
+
+            {
+                std::lock_guard<std::recursive_mutex> lck(lock_);
+                auto it_domain = domain_ips_.find(domain);
+                if (it_domain == domain_ips_.end()) {
+                    co_return;
+                }
+
+                auto& ips = it_domain->second;
+                ips.clear();
+                for (const auto& result : results) {
+                    ips.push_back(result.endpoint().address().to_string());
+                }
+            }
+            co_return;
+        },
+        boost::asio::detached);
 }
 
-std::optional<std::string> DnsService::resolve_domain_now(const std::string & domain)
-{
+std::optional<std::string> DnsService::resolve_domain_now(const std::string& domain) {
     boost::asio::io_context io_context;
     boost::asio::ip::tcp::resolver rslv(io_context);
-    boost::asio::ip::tcp::resolver::query qry(domain, boost::lexical_cast<std::string>(0));
-    boost::asio::ip::tcp::resolver::iterator iter = rslv.resolve(qry);
-    boost::asio::ip::tcp::resolver::iterator end;
-    if (iter == end) {
+    auto results = rslv.resolve(domain, "0");
+    if (results.empty()) {
         return std::nullopt;
     }
-    return (*iter).endpoint().address().to_string();
+    return results.begin()->endpoint().address().to_string();
 }

--- a/live-server/xmake.lua
+++ b/live-server/xmake.lua
@@ -1,0 +1,33 @@
+target("live-server", function ()
+    set_kind("binary")
+    add_files("**.cpp")
+    add_deps("base")
+    add_deps(
+        "protocol_http",
+        "protocol_mp4",
+        "protocol_rtmp",
+        "protocol_rtp",
+        "protocol_rtsp",
+        "protocol_sdp",
+        "protocol_ts"
+    )
+    add_deps("codec")
+    add_deps("sdk_http")
+    add_deps("server")
+
+    add_packages(
+        "spdlog",
+        "boost",
+        "yaml-cpp",
+        "jsoncpp",
+        "openssl3",
+        "zlib",
+        "libopus",
+        "faac",
+        "faad2",
+        "ffmpeg",
+        "srtp",
+        "hiredis",
+        "redis-plus-plus"
+    )
+end)

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,30 @@
+set_project("CuteSMS")
+set_xmakever("2.9.8")
+
+set_languages("c++20")
+
+add_rules("mode.debug", "mode.release")
+add_rules("plugin.compile_commands.autoupdate")
+
+set_defaultmode("debug")
+
+-- 第三方依赖
+add_requires("spdlog")
+add_requires("boost", { configs = { asio = true, program_options = true, system = true, thread = true, date_time = true, regex = true, serialization = true, context = true, coroutine = true }})
+add_requires("yaml-cpp")
+add_requires("jsoncpp")
+add_requires("openssl3")
+add_requires("zlib")
+add_requires("libopus")
+add_requires("faac")
+add_requires("faad2")
+add_requires("ffmpeg")
+add_requires("srtp")
+add_requires("hiredis")
+add_requires("redis-plus-plus")
+
+add_includedirs("libs")
+add_includedirs("live-server")
+
+includes("libs")
+includes("live-server")


### PR DESCRIPTION
`mms-server` 是一个很不错的高性能流媒体服务器项目，但是我使用 wsl2-Ubuntu24.04 或 Arch Linux 编译都会报错，初步判断是第三方库的编译问题。此 PR 主要做了以下事：

1. 增加 [`xmake`](https://xmake.io/#/zh-cn/) 构建支持，`xmake` 维护了 C++ 常用的第三方库（且版本较新），不需要通过 `cmake` 的 `ExternalProject_Add`。
2. 修复一些编译问题。（包括有些头文件未引入，以及 `boost` 库最新版本中已经移除的一些 api）

已经在本地编译成功。

编译方式：

1. 安装 `xmake`，在 `Arch Linux` 中通过 `sudo pacman -S xmake`。别的 Linux 发行版可以根据包管理器安装，详见 [官网](https://xmake.io/#/zh-cn/guide/installation)。
2. 打开终端，进入项目目录，执行 `xmake` 即可，会自动下载第三方库后再编译。