### PR TITLE
Support taskset and update xmake doc.

### DIFF
--- a/xmake_guide.md
+++ b/xmake_guide.md
@@ -12,10 +12,10 @@ sudo apt update
 sudo apt install xmake
 ```
 
-Additionally, please ensure that the `pkg-config` tool is installed. Because `xmake` needs to use `pkg-config` to obtain configuration information for dependency libraries.
+Additionally, please ensure that the `pkg-config` and `autoconf` tools are installed. Because `xmake` needs to use `pkg-config` to obtain configuration information for dependency libraries.
 
 ```bash
-sudo apt install pkg-config
+sudo apt install pkg-config autoconf
 ```
 
 ### 🐧 Arch Linux


### PR DESCRIPTION
1. 在一台机器上进行单机测试（回环网络）时，可以通过 `taskset -c` 指定进程使用核心数，本 PR 为 `main.cpp` 增加的代码可以：
- 灵活判断 `taskset` 设定的核心数
- 若没设置则默认 `std::thread::hardware_concurrency()`

2. 更新 `xmake_guide.md`