### PR TITLE
Fix dns service stop.

### DIFF
--- a/live-server/main.cpp
+++ b/live-server/main.cpp
@@ -29,27 +29,12 @@
 using namespace mms;
 
 void wait_exit() {
-    std::atomic_bool exit(false);
-    boost::asio::io_context io;
-    // 设置信号集捕获SIGINT/SIGTERM
-    boost::asio::signal_set sigset(io, SIGINT, SIGTERM);
-    // 异步等待目标信号并设置退出标志
-    sigset.async_wait([&exit](const boost::system::error_code &err, int signal) {
-        // 忽略signal和err(避免未使用变量警告)
-        ((void)signal);
-        ((void)err);
-        exit = true;
+    boost::asio::io_context io_ctx;
+    boost::asio::signal_set sigset(io_ctx, SIGINT, SIGTERM);
+    sigset.async_wait([&io_ctx](auto,auto) {
+        io_ctx.stop();
     });
-
-    boost::system::error_code ec;
-    // 开始事件循环(阻塞直到捕获SIGINT/SIGTERM)
-    io.run();
-    while (1) {
-        if (exit) {
-            break;
-        }
-        sleep(1);
-    }
+    io_ctx.run();
 }
 
 void init_log(bool is_debug_mode) {
@@ -313,6 +298,7 @@ int main(int argc, char *argv[]) {
         CORE_INFO("stop http live server done");
     }
 
+    DnsService::get_instance().stop();
     System::get_instance().uninit();
     thread_pool_inst::get_mutable_instance().stop();
     sleep(1);


### PR DESCRIPTION
- 在 `main.cpp` 中修复了 `DnsService` 最后忘记调用 `stop()` 关闭的问题。（也是需要按两次 `ctrl+c` 才能退出的原因）
- 优化 `wait_exit()` 函数